### PR TITLE
Add cascade trace to surface full routing journey

### DIFF
--- a/src/api/routes/tasks.ts
+++ b/src/api/routes/tasks.ts
@@ -1,9 +1,15 @@
 import { Hono } from "hono";
+import { RowDataPacket } from "mysql2";
 import { routeTask } from "../../router/router.js";
 import { findById } from "../../repositories/task-log.js";
 import { findByTaskId } from "../../repositories/execution-log.js";
+import { query } from "../../db/connection.js";
 import { RouterTaskInput } from "../../types/router.js";
 import { NotFoundError, ValidationError } from "../middleware/error-handler.js";
+
+interface MetadataRow extends RowDataPacket {
+  metadata: string | null;
+}
 
 const tasks = new Hono();
 
@@ -33,6 +39,27 @@ tasks.get("/tasks/:id", async (c) => {
   }
 
   return c.json({ ...task, executions }, 200);
+});
+
+tasks.get("/tasks/:id/trace", async (c) => {
+  const taskId = c.req.param("id");
+
+  const rows = await query<MetadataRow[]>(
+    "SELECT metadata FROM routing_log WHERE request_id = ? ORDER BY created_at DESC LIMIT 1",
+    [taskId],
+  );
+
+  const row = rows[0];
+  if (!row || !row.metadata) {
+    throw new NotFoundError(`No cascade trace found for task: ${taskId}`);
+  }
+
+  const parsed = JSON.parse(row.metadata);
+  if (!parsed.cascade_trace) {
+    throw new NotFoundError(`No cascade trace found for task: ${taskId}`);
+  }
+
+  return c.json(parsed.cascade_trace, 200);
 });
 
 export { tasks };

--- a/src/api/routes/tasks.ts
+++ b/src/api/routes/tasks.ts
@@ -1,15 +1,10 @@
 import { Hono } from "hono";
-import { RowDataPacket } from "mysql2";
 import { routeTask } from "../../router/router.js";
 import { findById } from "../../repositories/task-log.js";
 import { findByTaskId } from "../../repositories/execution-log.js";
-import { query } from "../../db/connection.js";
+import { findTraceByTaskId } from "../../cascade-router/reference-store.js";
 import { RouterTaskInput } from "../../types/router.js";
 import { NotFoundError, ValidationError } from "../middleware/error-handler.js";
-
-interface MetadataRow extends RowDataPacket {
-  metadata: string | null;
-}
 
 const tasks = new Hono();
 
@@ -43,23 +38,11 @@ tasks.get("/tasks/:id", async (c) => {
 
 tasks.get("/tasks/:id/trace", async (c) => {
   const taskId = c.req.param("id");
-
-  const rows = await query<MetadataRow[]>(
-    "SELECT metadata FROM routing_log WHERE request_id = ? ORDER BY created_at DESC LIMIT 1",
-    [taskId],
-  );
-
-  const row = rows[0];
-  if (!row || !row.metadata) {
+  const trace = await findTraceByTaskId(taskId);
+  if (!trace) {
     throw new NotFoundError(`No cascade trace found for task: ${taskId}`);
   }
-
-  const parsed = JSON.parse(row.metadata);
-  if (!parsed.cascade_trace) {
-    throw new NotFoundError(`No cascade trace found for task: ${taskId}`);
-  }
-
-  return c.json(parsed.cascade_trace, 200);
+  return c.json(trace, 200);
 });
 
 export { tasks };

--- a/src/cascade-router/cascade-router.ts
+++ b/src/cascade-router/cascade-router.ts
@@ -10,6 +10,7 @@ import type {
   LayerAttempt,
   CascadeTrace,
 } from "./types.js";
+import { skippedAttempt } from "./types.js";
 import { matchRules } from "../classifier/rules.js";
 import { costCeilingForTier } from "../classifier/scoring.js";
 import { uuidv7, sha256 } from "../types/task.js";
@@ -110,33 +111,9 @@ export class CascadeRouter {
         tier: metadata.tier,
         reason: "metadata tier override",
       });
-      trace.push({
-        layer: "semantic",
-        status: "skipped",
-        confidence: null,
-        similarity_score: null,
-        latency_ms: 0,
-        tier: null,
-        reason: "metadata override — skipped",
-      });
-      trace.push({
-        layer: "escalation",
-        status: "skipped",
-        confidence: null,
-        similarity_score: null,
-        latency_ms: 0,
-        tier: null,
-        reason: "metadata override — skipped",
-      });
-      trace.push({
-        layer: "fallback",
-        status: "skipped",
-        confidence: null,
-        similarity_score: null,
-        latency_ms: 0,
-        tier: null,
-        reason: "metadata override — skipped",
-      });
+      trace.push(skippedAttempt("semantic", "metadata override — skipped"));
+      trace.push(skippedAttempt("escalation", "metadata override — skipped"));
+      trace.push(skippedAttempt("fallback", "metadata override — skipped"));
     } else {
       // Layer 0: Deterministic rules
       const l0Start = performance.now();
@@ -161,33 +138,9 @@ export class CascadeRouter {
           reason: "rule matched",
         });
         // Remaining layers skipped
-        trace.push({
-          layer: "semantic",
-          status: "skipped",
-          confidence: null,
-          similarity_score: null,
-          latency_ms: 0,
-          tier: null,
-          reason: "deterministic layer resolved",
-        });
-        trace.push({
-          layer: "escalation",
-          status: "skipped",
-          confidence: null,
-          similarity_score: null,
-          latency_ms: 0,
-          tier: null,
-          reason: "deterministic layer resolved",
-        });
-        trace.push({
-          layer: "fallback",
-          status: "skipped",
-          confidence: null,
-          similarity_score: null,
-          latency_ms: 0,
-          tier: null,
-          reason: "deterministic layer resolved",
-        });
+        trace.push(skippedAttempt("semantic", "deterministic layer resolved"));
+        trace.push(skippedAttempt("escalation", "deterministic layer resolved"));
+        trace.push(skippedAttempt("fallback", "deterministic layer resolved"));
       } else {
         trace.push({
           layer: "deterministic",
@@ -222,24 +175,8 @@ export class CascadeRouter {
               tier: vote.tier,
               reason: `confidence ${vote.confidence.toFixed(2)} >= threshold ${config.similarity_threshold}`,
             });
-            trace.push({
-              layer: "escalation",
-              status: "skipped",
-              confidence: null,
-              similarity_score: null,
-              latency_ms: 0,
-              tier: null,
-              reason: "semantic layer resolved",
-            });
-            trace.push({
-              layer: "fallback",
-              status: "skipped",
-              confidence: null,
-              similarity_score: null,
-              latency_ms: 0,
-              tier: null,
-              reason: "semantic layer resolved",
-            });
+            trace.push(skippedAttempt("escalation", "semantic layer resolved"));
+            trace.push(skippedAttempt("fallback", "semantic layer resolved"));
           } else {
             trace.push({
               layer: "semantic",
@@ -266,15 +203,7 @@ export class CascadeRouter {
           // No utterances/embeddings — skip semantic
           const skipReason =
             utterances.length === 0 ? "no reference utterances" : "no embedding provider";
-          trace.push({
-            layer: "semantic",
-            status: "skipped",
-            confidence: null,
-            similarity_score: null,
-            latency_ms: 0,
-            tier: null,
-            reason: skipReason,
-          });
+          trace.push(skippedAttempt("semantic", skipReason));
 
           // Layer 2: LLM escalation (no semantic available)
           const esc = await this.tryEscalation(prompt, config, tiers, allCapabilities);
@@ -356,15 +285,7 @@ export class CascadeRouter {
           : "no tier definitions";
       return {
         resolved: false,
-        attempt: {
-          layer: "escalation",
-          status: "skipped",
-          confidence: null,
-          similarity_score: null,
-          latency_ms: 0,
-          tier: null,
-          reason,
-        },
+        attempt: skippedAttempt("escalation", reason),
       };
     }
 
@@ -388,15 +309,7 @@ export class CascadeRouter {
           tier: escalation.tier,
           reason: "LLM classification resolved",
         },
-        fallbackAttempt: {
-          layer: "fallback",
-          status: "skipped",
-          confidence: null,
-          similarity_score: null,
-          latency_ms: 0,
-          tier: null,
-          reason: "escalation layer resolved",
-        },
+        fallbackAttempt: skippedAttempt("fallback", "escalation layer resolved"),
       };
     } catch (err) {
       const l2Latency = performance.now() - l2Start;

--- a/src/cascade-router/cascade-router.ts
+++ b/src/cascade-router/cascade-router.ts
@@ -7,6 +7,8 @@ import type {
   RoutingDecision,
   EmbeddingProvider,
   EscalationProvider,
+  LayerAttempt,
+  CascadeTrace,
 } from "./types.js";
 import { matchRules } from "../classifier/rules.js";
 import { costCeilingForTier } from "../classifier/scoring.js";
@@ -75,6 +77,7 @@ export class CascadeRouter {
     const start = performance.now();
     const prompt = input.prompt;
     const metadata = input.metadata;
+    const trace: LayerAttempt[] = [];
 
     // Always run regex capability detection
     const { capabilities: regexCapabilities } = matchRules(prompt);
@@ -90,99 +93,353 @@ export class CascadeRouter {
     let layer: RoutingDecision["layer"];
     let confidence = 1.0;
     let similarityScore: number | null = null;
+    let resolved = false;
 
     // Metadata tier override — skip all layers
     if (metadata?.tier !== undefined) {
       tier = metadata.tier;
       layer = "deterministic";
       confidence = 1.0;
+      resolved = true;
+      trace.push({
+        layer: "deterministic",
+        status: "matched",
+        confidence: 1.0,
+        similarity_score: null,
+        latency_ms: performance.now() - start,
+        tier: metadata.tier,
+        reason: "metadata tier override",
+      });
+      trace.push({
+        layer: "semantic",
+        status: "skipped",
+        confidence: null,
+        similarity_score: null,
+        latency_ms: 0,
+        tier: null,
+        reason: "metadata override — skipped",
+      });
+      trace.push({
+        layer: "escalation",
+        status: "skipped",
+        confidence: null,
+        similarity_score: null,
+        latency_ms: 0,
+        tier: null,
+        reason: "metadata override — skipped",
+      });
+      trace.push({
+        layer: "fallback",
+        status: "skipped",
+        confidence: null,
+        similarity_score: null,
+        latency_ms: 0,
+        tier: null,
+        reason: "metadata override — skipped",
+      });
     } else {
       // Layer 0: Deterministic rules
+      const l0Start = performance.now();
       const l0Result = this.runDeterministicRules(prompt, rules);
+      const l0Latency = performance.now() - l0Start;
 
       if (l0Result) {
         tier = l0Result.tier;
         layer = "deterministic";
         confidence = 1.0;
-        // Merge capabilities from matched rules
+        resolved = true;
         for (const cap of l0Result.capabilities) {
           allCapabilities.add(cap);
         }
-      } else if (utterances.length > 0 && this.embeddingProvider) {
-        // Layer 1: Semantic similarity
-        const queryEmbedding = await this.embeddingProvider.embed(prompt);
-        const matches = rankBySimilarity(queryEmbedding, utterances, config.top_k);
-        const vote = weightedTierVote(matches);
-        similarityScore = matches.length > 0 ? matches[0].score : null;
+        trace.push({
+          layer: "deterministic",
+          status: "matched",
+          confidence: 1.0,
+          similarity_score: null,
+          latency_ms: l0Latency,
+          tier: l0Result.tier,
+          reason: "rule matched",
+        });
+        // Remaining layers skipped
+        trace.push({
+          layer: "semantic",
+          status: "skipped",
+          confidence: null,
+          similarity_score: null,
+          latency_ms: 0,
+          tier: null,
+          reason: "deterministic layer resolved",
+        });
+        trace.push({
+          layer: "escalation",
+          status: "skipped",
+          confidence: null,
+          similarity_score: null,
+          latency_ms: 0,
+          tier: null,
+          reason: "deterministic layer resolved",
+        });
+        trace.push({
+          layer: "fallback",
+          status: "skipped",
+          confidence: null,
+          similarity_score: null,
+          latency_ms: 0,
+          tier: null,
+          reason: "deterministic layer resolved",
+        });
+      } else {
+        trace.push({
+          layer: "deterministic",
+          status: "missed",
+          confidence: null,
+          similarity_score: null,
+          latency_ms: l0Latency,
+          tier: null,
+          reason: "no rules matched",
+        });
 
-        if (vote.confidence >= config.similarity_threshold) {
-          tier = vote.tier;
-          layer = "semantic";
-          confidence = vote.confidence;
-        } else if (
-          vote.confidence >= config.escalation_threshold &&
-          config.enable_escalation &&
-          this.escalationProvider &&
-          tiers.length > 0
-        ) {
-          // Layer 2: LLM escalation
-          const escalation = await this.escalationProvider.classify(prompt, tiers);
-          tier = escalation.tier;
-          layer = "escalation";
-          confidence = escalation.confidence;
-          for (const cap of escalation.capabilities) {
-            allCapabilities.add(cap);
-          }
-        } else if (config.enable_escalation && this.escalationProvider && tiers.length > 0) {
-          // Low confidence — also escalate
-          const escalation = await this.escalationProvider.classify(prompt, tiers);
-          tier = escalation.tier;
-          layer = "escalation";
-          confidence = escalation.confidence;
-          for (const cap of escalation.capabilities) {
-            allCapabilities.add(cap);
+        // Layer 1: Semantic similarity
+        if (utterances.length > 0 && this.embeddingProvider) {
+          const l1Start = performance.now();
+          const queryEmbedding = await this.embeddingProvider.embed(prompt);
+          const matches = rankBySimilarity(queryEmbedding, utterances, config.top_k);
+          const vote = weightedTierVote(matches);
+          const l1Latency = performance.now() - l1Start;
+          similarityScore = matches.length > 0 ? matches[0].score : null;
+
+          if (vote.confidence >= config.similarity_threshold) {
+            tier = vote.tier;
+            layer = "semantic";
+            confidence = vote.confidence;
+            resolved = true;
+            trace.push({
+              layer: "semantic",
+              status: "matched",
+              confidence: vote.confidence,
+              similarity_score: similarityScore,
+              latency_ms: l1Latency,
+              tier: vote.tier,
+              reason: `confidence ${vote.confidence.toFixed(2)} >= threshold ${config.similarity_threshold}`,
+            });
+            trace.push({
+              layer: "escalation",
+              status: "skipped",
+              confidence: null,
+              similarity_score: null,
+              latency_ms: 0,
+              tier: null,
+              reason: "semantic layer resolved",
+            });
+            trace.push({
+              layer: "fallback",
+              status: "skipped",
+              confidence: null,
+              similarity_score: null,
+              latency_ms: 0,
+              tier: null,
+              reason: "semantic layer resolved",
+            });
+          } else {
+            trace.push({
+              layer: "semantic",
+              status: "missed",
+              confidence: vote.confidence,
+              similarity_score: similarityScore,
+              latency_ms: l1Latency,
+              tier: vote.tier,
+              reason: `confidence ${vote.confidence.toFixed(2)} < threshold ${config.similarity_threshold}`,
+            });
+
+            // Layer 2: LLM escalation
+            if (config.enable_escalation && this.escalationProvider && tiers.length > 0) {
+              const l2Start = performance.now();
+              try {
+                const escalation = await this.escalationProvider.classify(prompt, tiers);
+                const l2Latency = performance.now() - l2Start;
+                tier = escalation.tier;
+                layer = "escalation";
+                confidence = escalation.confidence;
+                resolved = true;
+                for (const cap of escalation.capabilities) {
+                  allCapabilities.add(cap);
+                }
+                trace.push({
+                  layer: "escalation",
+                  status: "matched",
+                  confidence: escalation.confidence,
+                  similarity_score: null,
+                  latency_ms: l2Latency,
+                  tier: escalation.tier,
+                  reason: "LLM classification resolved",
+                });
+                trace.push({
+                  layer: "fallback",
+                  status: "skipped",
+                  confidence: null,
+                  similarity_score: null,
+                  latency_ms: 0,
+                  tier: null,
+                  reason: "escalation layer resolved",
+                });
+              } catch (err) {
+                const l2Latency = performance.now() - l2Start;
+                trace.push({
+                  layer: "escalation",
+                  status: "error",
+                  confidence: null,
+                  similarity_score: null,
+                  latency_ms: l2Latency,
+                  tier: null,
+                  reason: `escalation failed: ${(err as Error).message}`,
+                });
+              }
+            } else {
+              const skipReason = !config.enable_escalation
+                ? "escalation disabled"
+                : !this.escalationProvider
+                  ? "no escalation provider"
+                  : "no tier definitions";
+              trace.push({
+                layer: "escalation",
+                status: "skipped",
+                confidence: null,
+                similarity_score: null,
+                latency_ms: 0,
+                tier: null,
+                reason: skipReason,
+              });
+            }
           }
         } else {
-          // Fallback
+          // No utterances/embeddings — skip semantic
+          const skipReason =
+            utterances.length === 0 ? "no reference utterances" : "no embedding provider";
+          trace.push({
+            layer: "semantic",
+            status: "skipped",
+            confidence: null,
+            similarity_score: null,
+            latency_ms: 0,
+            tier: null,
+            reason: skipReason,
+          });
+
+          // Layer 2: LLM escalation (no semantic available)
+          if (config.enable_escalation && this.escalationProvider && tiers.length > 0) {
+            const l2Start = performance.now();
+            try {
+              const escalation = await this.escalationProvider.classify(prompt, tiers);
+              const l2Latency = performance.now() - l2Start;
+              tier = escalation.tier;
+              layer = "escalation";
+              confidence = escalation.confidence;
+              resolved = true;
+              for (const cap of escalation.capabilities) {
+                allCapabilities.add(cap);
+              }
+              trace.push({
+                layer: "escalation",
+                status: "matched",
+                confidence: escalation.confidence,
+                similarity_score: null,
+                latency_ms: l2Latency,
+                tier: escalation.tier,
+                reason: "LLM classification resolved",
+              });
+              trace.push({
+                layer: "fallback",
+                status: "skipped",
+                confidence: null,
+                similarity_score: null,
+                latency_ms: 0,
+                tier: null,
+                reason: "escalation layer resolved",
+              });
+            } catch (err) {
+              const l2Latency = performance.now() - l2Start;
+              trace.push({
+                layer: "escalation",
+                status: "error",
+                confidence: null,
+                similarity_score: null,
+                latency_ms: l2Latency,
+                tier: null,
+                reason: `escalation failed: ${(err as Error).message}`,
+              });
+            }
+          } else {
+            const skipReason = !config.enable_escalation
+              ? "escalation disabled"
+              : !this.escalationProvider
+                ? "no escalation provider"
+                : "no tier definitions";
+            trace.push({
+              layer: "escalation",
+              status: "skipped",
+              confidence: null,
+              similarity_score: null,
+              latency_ms: 0,
+              tier: null,
+              reason: skipReason,
+            });
+          }
+        }
+
+        // Fallback — if nothing resolved yet
+        if (!resolved) {
           tier = config.default_tier;
           layer = "fallback";
           confidence = 0;
+          trace.push({
+            layer: "fallback",
+            status: "matched",
+            confidence: 0,
+            similarity_score: null,
+            latency_ms: 0,
+            tier: config.default_tier,
+            reason: `defaulting to T${config.default_tier}`,
+          });
         }
-      } else if (config.enable_escalation && this.escalationProvider && tiers.length > 0) {
-        // No utterances but escalation available
-        const escalation = await this.escalationProvider.classify(prompt, tiers);
-        tier = escalation.tier;
-        layer = "escalation";
-        confidence = escalation.confidence;
-        for (const cap of escalation.capabilities) {
-          allCapabilities.add(cap);
-        }
-      } else {
-        // Fallback
-        tier = config.default_tier;
-        layer = "fallback";
-        confidence = 0;
       }
     }
 
     const latencyMs = performance.now() - start;
     const taskId = uuidv7();
 
+    const cascadeTrace: CascadeTrace = {
+      layers: trace,
+      resolved_layer: layer!,
+      total_latency_ms: latencyMs,
+    };
+
     // Best-effort log
     try {
-      await store.logDecision(taskId, prompt, tier, layer, similarityScore, confidence, latencyMs);
+      await store.logDecision(
+        taskId,
+        prompt,
+        tier!,
+        layer!,
+        similarityScore,
+        confidence,
+        latencyMs,
+        {
+          cascade_trace: cascadeTrace,
+        },
+      );
     } catch {
       // Don't fail classification if logging fails
     }
 
     return {
       task_id: taskId,
-      complexity_tier: tier,
+      complexity_tier: tier!,
       required_capabilities: [...allCapabilities],
-      cost_ceiling_usd: costCeilingForTier(tier),
+      cost_ceiling_usd: costCeilingForTier(tier!),
       prompt_hash: sha256(prompt),
       routing_confidence: confidence,
-      routing_layer: layer,
+      routing_layer: layer!,
+      cascade_trace: cascadeTrace,
     };
   }
 

--- a/src/cascade-router/cascade-router.ts
+++ b/src/cascade-router/cascade-router.ts
@@ -89,8 +89,8 @@ export class CascadeRouter {
       }
     }
 
-    let tier: TierId;
-    let layer: RoutingDecision["layer"];
+    let tier: TierId = config.default_tier;
+    let layer: RoutingDecision["layer"] = "fallback";
     let confidence = 1.0;
     let similarityScore: number | null = null;
     let resolved = false;
@@ -252,63 +252,14 @@ export class CascadeRouter {
             });
 
             // Layer 2: LLM escalation
-            if (config.enable_escalation && this.escalationProvider && tiers.length > 0) {
-              const l2Start = performance.now();
-              try {
-                const escalation = await this.escalationProvider.classify(prompt, tiers);
-                const l2Latency = performance.now() - l2Start;
-                tier = escalation.tier;
-                layer = "escalation";
-                confidence = escalation.confidence;
-                resolved = true;
-                for (const cap of escalation.capabilities) {
-                  allCapabilities.add(cap);
-                }
-                trace.push({
-                  layer: "escalation",
-                  status: "matched",
-                  confidence: escalation.confidence,
-                  similarity_score: null,
-                  latency_ms: l2Latency,
-                  tier: escalation.tier,
-                  reason: "LLM classification resolved",
-                });
-                trace.push({
-                  layer: "fallback",
-                  status: "skipped",
-                  confidence: null,
-                  similarity_score: null,
-                  latency_ms: 0,
-                  tier: null,
-                  reason: "escalation layer resolved",
-                });
-              } catch (err) {
-                const l2Latency = performance.now() - l2Start;
-                trace.push({
-                  layer: "escalation",
-                  status: "error",
-                  confidence: null,
-                  similarity_score: null,
-                  latency_ms: l2Latency,
-                  tier: null,
-                  reason: `escalation failed: ${(err as Error).message}`,
-                });
-              }
-            } else {
-              const skipReason = !config.enable_escalation
-                ? "escalation disabled"
-                : !this.escalationProvider
-                  ? "no escalation provider"
-                  : "no tier definitions";
-              trace.push({
-                layer: "escalation",
-                status: "skipped",
-                confidence: null,
-                similarity_score: null,
-                latency_ms: 0,
-                tier: null,
-                reason: skipReason,
-              });
+            const esc = await this.tryEscalation(prompt, config, tiers, allCapabilities);
+            trace.push(esc.attempt);
+            if (esc.resolved) {
+              tier = esc.tier!;
+              layer = "escalation";
+              confidence = esc.confidence!;
+              resolved = true;
+              if (esc.fallbackAttempt) trace.push(esc.fallbackAttempt);
             }
           }
         } else {
@@ -326,63 +277,14 @@ export class CascadeRouter {
           });
 
           // Layer 2: LLM escalation (no semantic available)
-          if (config.enable_escalation && this.escalationProvider && tiers.length > 0) {
-            const l2Start = performance.now();
-            try {
-              const escalation = await this.escalationProvider.classify(prompt, tiers);
-              const l2Latency = performance.now() - l2Start;
-              tier = escalation.tier;
-              layer = "escalation";
-              confidence = escalation.confidence;
-              resolved = true;
-              for (const cap of escalation.capabilities) {
-                allCapabilities.add(cap);
-              }
-              trace.push({
-                layer: "escalation",
-                status: "matched",
-                confidence: escalation.confidence,
-                similarity_score: null,
-                latency_ms: l2Latency,
-                tier: escalation.tier,
-                reason: "LLM classification resolved",
-              });
-              trace.push({
-                layer: "fallback",
-                status: "skipped",
-                confidence: null,
-                similarity_score: null,
-                latency_ms: 0,
-                tier: null,
-                reason: "escalation layer resolved",
-              });
-            } catch (err) {
-              const l2Latency = performance.now() - l2Start;
-              trace.push({
-                layer: "escalation",
-                status: "error",
-                confidence: null,
-                similarity_score: null,
-                latency_ms: l2Latency,
-                tier: null,
-                reason: `escalation failed: ${(err as Error).message}`,
-              });
-            }
-          } else {
-            const skipReason = !config.enable_escalation
-              ? "escalation disabled"
-              : !this.escalationProvider
-                ? "no escalation provider"
-                : "no tier definitions";
-            trace.push({
-              layer: "escalation",
-              status: "skipped",
-              confidence: null,
-              similarity_score: null,
-              latency_ms: 0,
-              tier: null,
-              reason: skipReason,
-            });
+          const esc = await this.tryEscalation(prompt, config, tiers, allCapabilities);
+          trace.push(esc.attempt);
+          if (esc.resolved) {
+            tier = esc.tier!;
+            layer = "escalation";
+            confidence = esc.confidence!;
+            resolved = true;
+            if (esc.fallbackAttempt) trace.push(esc.fallbackAttempt);
           }
         }
 
@@ -409,38 +311,109 @@ export class CascadeRouter {
 
     const cascadeTrace: CascadeTrace = {
       layers: trace,
-      resolved_layer: layer!,
+      resolved_layer: layer,
       total_latency_ms: latencyMs,
     };
 
     // Best-effort log
     try {
-      await store.logDecision(
-        taskId,
-        prompt,
-        tier!,
-        layer!,
-        similarityScore,
-        confidence,
-        latencyMs,
-        {
-          cascade_trace: cascadeTrace,
-        },
-      );
+      await store.logDecision(taskId, prompt, tier, layer, similarityScore, confidence, latencyMs, {
+        cascade_trace: cascadeTrace,
+      });
     } catch {
       // Don't fail classification if logging fails
     }
 
     return {
       task_id: taskId,
-      complexity_tier: tier!,
+      complexity_tier: tier,
       required_capabilities: [...allCapabilities],
-      cost_ceiling_usd: costCeilingForTier(tier!),
+      cost_ceiling_usd: costCeilingForTier(tier),
       prompt_hash: sha256(prompt),
       routing_confidence: confidence,
-      routing_layer: layer!,
+      routing_layer: layer,
       cascade_trace: cascadeTrace,
     };
+  }
+
+  private async tryEscalation(
+    prompt: string,
+    config: RouterConfig,
+    tiers: TierDefinition[],
+    allCapabilities: Set<string>,
+  ): Promise<{
+    resolved: boolean;
+    tier?: TierId;
+    confidence?: number;
+    attempt: LayerAttempt;
+    fallbackAttempt?: LayerAttempt;
+  }> {
+    if (!config.enable_escalation || !this.escalationProvider || tiers.length === 0) {
+      const reason = !config.enable_escalation
+        ? "escalation disabled"
+        : !this.escalationProvider
+          ? "no escalation provider"
+          : "no tier definitions";
+      return {
+        resolved: false,
+        attempt: {
+          layer: "escalation",
+          status: "skipped",
+          confidence: null,
+          similarity_score: null,
+          latency_ms: 0,
+          tier: null,
+          reason,
+        },
+      };
+    }
+
+    const l2Start = performance.now();
+    try {
+      const escalation = await this.escalationProvider.classify(prompt, tiers);
+      const l2Latency = performance.now() - l2Start;
+      for (const cap of escalation.capabilities) {
+        allCapabilities.add(cap);
+      }
+      return {
+        resolved: true,
+        tier: escalation.tier,
+        confidence: escalation.confidence,
+        attempt: {
+          layer: "escalation",
+          status: "matched",
+          confidence: escalation.confidence,
+          similarity_score: null,
+          latency_ms: l2Latency,
+          tier: escalation.tier,
+          reason: "LLM classification resolved",
+        },
+        fallbackAttempt: {
+          layer: "fallback",
+          status: "skipped",
+          confidence: null,
+          similarity_score: null,
+          latency_ms: 0,
+          tier: null,
+          reason: "escalation layer resolved",
+        },
+      };
+    } catch (err) {
+      const l2Latency = performance.now() - l2Start;
+      const message = (err as Error).message ?? String(err);
+      return {
+        resolved: false,
+        attempt: {
+          layer: "escalation",
+          status: "error",
+          confidence: null,
+          similarity_score: null,
+          latency_ms: l2Latency,
+          tier: null,
+          reason: `escalation failed: ${message.slice(0, 200)}`,
+        },
+      };
+    }
   }
 
   private runDeterministicRules(

--- a/src/cascade-router/reference-store.ts
+++ b/src/cascade-router/reference-store.ts
@@ -36,6 +36,10 @@ interface CountRow extends RowDataPacket {
   cnt: number;
 }
 
+interface MetadataRow extends RowDataPacket {
+  metadata: string | null;
+}
+
 export async function loadRules(): Promise<RoutingRule[]> {
   const rows = await query<RuleRow[]>(
     `SELECT rule_id, tier_id, rule_type, pattern, capabilities, priority, enabled, description
@@ -176,6 +180,26 @@ export async function logDecision(
       metadata ? JSON.stringify(metadata) : null,
     ],
   );
+}
+
+export async function findTraceByTaskId(taskId: string): Promise<Record<string, unknown> | null> {
+  const rows = await query<MetadataRow[]>(
+    "SELECT metadata FROM routing_log WHERE request_id = ? ORDER BY created_at DESC LIMIT 1",
+    [taskId],
+  );
+  const row = rows[0];
+  if (!row || !row.metadata) return null;
+
+  let parsed: Record<string, unknown>;
+  try {
+    parsed = JSON.parse(
+      typeof row.metadata === "string" ? row.metadata : JSON.stringify(row.metadata),
+    );
+  } catch {
+    return null;
+  }
+
+  return (parsed.cascade_trace as Record<string, unknown>) ?? null;
 }
 
 export async function hasEmbeddings(): Promise<boolean> {

--- a/src/cascade-router/reference-store.ts
+++ b/src/cascade-router/reference-store.ts
@@ -2,12 +2,14 @@ import { query, execute } from "../db/connection.js";
 import { uuidv7 } from "../types/task.js";
 import type { RowDataPacket } from "mysql2/promise";
 import type {
+  CascadeTrace,
   RoutingRule,
   ReferenceUtterance,
   RouterConfig,
   RoutingLayer,
   TierId,
 } from "./types.js";
+import { CascadeTraceSchema } from "./types.js";
 
 interface RuleRow extends RowDataPacket {
   rule_id: string;
@@ -182,7 +184,7 @@ export async function logDecision(
   );
 }
 
-export async function findTraceByTaskId(taskId: string): Promise<Record<string, unknown> | null> {
+export async function findTraceByTaskId(taskId: string): Promise<CascadeTrace | null> {
   const rows = await query<MetadataRow[]>(
     "SELECT metadata FROM routing_log WHERE request_id = ? ORDER BY created_at DESC LIMIT 1",
     [taskId],
@@ -199,7 +201,8 @@ export async function findTraceByTaskId(taskId: string): Promise<Record<string, 
     return null;
   }
 
-  return (parsed.cascade_trace as Record<string, unknown>) ?? null;
+  const result = CascadeTraceSchema.safeParse(parsed.cascade_trace);
+  return result.success ? result.data : null;
 }
 
 export async function hasEmbeddings(): Promise<boolean> {

--- a/src/cascade-router/types.ts
+++ b/src/cascade-router/types.ts
@@ -60,6 +60,24 @@ export interface RoutingDecision {
   latency_ms: number;
 }
 
+export type LayerAttemptStatus = "matched" | "missed" | "skipped" | "error";
+
+export interface LayerAttempt {
+  layer: RoutingLayer;
+  status: LayerAttemptStatus;
+  confidence: number | null;
+  similarity_score: number | null;
+  latency_ms: number;
+  tier: TierId | null;
+  reason: string;
+}
+
+export interface CascadeTrace {
+  layers: LayerAttempt[];
+  resolved_layer: RoutingLayer;
+  total_latency_ms: number;
+}
+
 export interface SimilarityMatch {
   utterance_id: string;
   tier_id: TierId;

--- a/src/cascade-router/types.ts
+++ b/src/cascade-router/types.ts
@@ -59,24 +59,7 @@ export interface RoutingDecision {
   confidence: number;
   similarity_score?: number;
   latency_ms: number;
-}
-
-export type LayerAttemptStatus = "matched" | "missed" | "skipped" | "error";
-
-export interface LayerAttempt {
-  layer: RoutingLayer;
-  status: LayerAttemptStatus;
-  confidence: number | null;
-  similarity_score: number | null;
-  latency_ms: number;
-  tier: TierId | null;
-  reason: string;
-}
-
-export interface CascadeTrace {
-  layers: LayerAttempt[];
-  resolved_layer: RoutingLayer;
-  total_latency_ms: number;
+  cascade_trace?: CascadeTrace;
 }
 
 export const LayerAttemptSchema = z.object({
@@ -89,11 +72,15 @@ export const LayerAttemptSchema = z.object({
   reason: z.string(),
 });
 
+export type LayerAttempt = z.infer<typeof LayerAttemptSchema>;
+
 export const CascadeTraceSchema = z.object({
   layers: z.array(LayerAttemptSchema),
   resolved_layer: z.enum(["deterministic", "semantic", "escalation", "fallback"]),
   total_latency_ms: z.number(),
 });
+
+export type CascadeTrace = z.infer<typeof CascadeTraceSchema>;
 
 export function skippedAttempt(layer: RoutingLayer, reason: string): LayerAttempt {
   return {

--- a/src/cascade-router/types.ts
+++ b/src/cascade-router/types.ts
@@ -1,3 +1,4 @@
+import { z } from "zod";
 import type { ComplexityTier } from "../types/task.js";
 
 // Re-export for convenience
@@ -76,6 +77,34 @@ export interface CascadeTrace {
   layers: LayerAttempt[];
   resolved_layer: RoutingLayer;
   total_latency_ms: number;
+}
+
+export const LayerAttemptSchema = z.object({
+  layer: z.enum(["deterministic", "semantic", "escalation", "fallback"]),
+  status: z.enum(["matched", "missed", "skipped", "error"]),
+  confidence: z.number().nullable(),
+  similarity_score: z.number().nullable(),
+  latency_ms: z.number(),
+  tier: z.union([z.literal(1), z.literal(2), z.literal(3), z.literal(4)]).nullable(),
+  reason: z.string(),
+});
+
+export const CascadeTraceSchema = z.object({
+  layers: z.array(LayerAttemptSchema),
+  resolved_layer: z.enum(["deterministic", "semantic", "escalation", "fallback"]),
+  total_latency_ms: z.number(),
+});
+
+export function skippedAttempt(layer: RoutingLayer, reason: string): LayerAttempt {
+  return {
+    layer,
+    status: "skipped",
+    confidence: null,
+    similarity_score: null,
+    latency_ms: 0,
+    tier: null,
+    reason,
+  };
 }
 
 export interface SimilarityMatch {

--- a/src/classifier/classifier.ts
+++ b/src/classifier/classifier.ts
@@ -1,5 +1,6 @@
 import { TaskInput, type TaskClassification, uuidv7, sha256 } from "../types/task.js";
 import type { CascadeTrace, LayerAttempt } from "../cascade-router/types.js";
+import { skippedAttempt } from "../cascade-router/types.js";
 import { matchRules } from "./rules.js";
 import { computeTier, costCeilingForTier } from "./scoring.js";
 
@@ -51,15 +52,7 @@ export function classify(input: TaskInput): TaskClassification {
   };
 
   const skippedLayers: LayerAttempt[] = (["semantic", "escalation", "fallback"] as const).map(
-    (layer) => ({
-      layer,
-      status: "skipped" as const,
-      confidence: null,
-      similarity_score: null,
-      latency_ms: 0,
-      tier: null,
-      reason: "legacy classifier — skipped",
-    }),
+    (layer) => skippedAttempt(layer, "legacy classifier — skipped"),
   );
 
   const cascade_trace: CascadeTrace = {

--- a/src/classifier/classifier.ts
+++ b/src/classifier/classifier.ts
@@ -1,8 +1,11 @@
 import { TaskInput, type TaskClassification, uuidv7, sha256 } from "../types/task.js";
+import type { CascadeTrace, LayerAttempt } from "../cascade-router/types.js";
 import { matchRules } from "./rules.js";
 import { computeTier, costCeilingForTier } from "./scoring.js";
 
 export function classify(input: TaskInput): TaskClassification {
+  const start = performance.now();
+
   // 1. Validate input with Zod
   const parsed = TaskInput.parse(input);
 
@@ -34,11 +37,45 @@ export function classify(input: TaskInput): TaskClassification {
   const task_id = uuidv7();
   const prompt_hash = sha256(parsed.prompt);
 
+  const elapsed = performance.now() - start;
+
+  // 7. Build cascade trace for legacy classifier
+  const deterministicAttempt: LayerAttempt = {
+    layer: "deterministic",
+    status: "matched",
+    confidence: 1.0,
+    similarity_score: null,
+    latency_ms: elapsed,
+    tier,
+    reason: "legacy rule-based classifier — deterministic match",
+  };
+
+  const skippedLayers: LayerAttempt[] = (["semantic", "escalation", "fallback"] as const).map(
+    (layer) => ({
+      layer,
+      status: "skipped" as const,
+      confidence: null,
+      similarity_score: null,
+      latency_ms: 0,
+      tier: null,
+      reason: "legacy classifier — skipped",
+    }),
+  );
+
+  const cascade_trace: CascadeTrace = {
+    layers: [deterministicAttempt, ...skippedLayers],
+    resolved_layer: "deterministic",
+    total_latency_ms: elapsed,
+  };
+
   return {
     task_id,
     complexity_tier: tier,
     required_capabilities: allCapabilities,
     cost_ceiling_usd,
     prompt_hash,
+    routing_confidence: 1.0,
+    routing_layer: "deterministic",
+    cascade_trace,
   };
 }

--- a/src/router/router.ts
+++ b/src/router/router.ts
@@ -19,6 +19,7 @@ import {
   evaluateRoutingDecision,
 } from "../services/outcome-collector.js";
 import { loadConfig } from "../cascade-router/reference-store.js";
+import type { CascadeTrace } from "../cascade-router/types.js";
 
 export const DEFAULT_TIMEOUT_MS: Record<ComplexityTier, number> = {
   1: 15_000,
@@ -42,6 +43,7 @@ export async function routeTask(input: RouterTaskInput): Promise<TaskResult> {
 
   let taskId: string | null = null;
   let status: TaskResult["status"] = "RECEIVED";
+  let cascadeTrace: CascadeTrace | undefined;
 
   try {
     // 1. Classify — try cascade router, fall back to old classifier
@@ -58,6 +60,7 @@ export async function routeTask(input: RouterTaskInput): Promise<TaskResult> {
       });
     }
     taskId = classification.task_id;
+    cascadeTrace = classification.cascade_trace;
 
     // 2. Intake — write to task_log
     await taskLog.create(taskId, classification.prompt_hash);
@@ -206,6 +209,7 @@ export async function routeTask(input: RouterTaskInput): Promise<TaskResult> {
       cost_usd: execResult.cost_usd,
       latency_ms: execResult.latency_ms,
       error: execResult.error_detail,
+      cascade_trace: cascadeTrace,
     };
   } catch (err) {
     // On any error, mark as failed and still commit
@@ -231,6 +235,7 @@ export async function routeTask(input: RouterTaskInput): Promise<TaskResult> {
       cost_usd: null,
       latency_ms: null,
       error: (err as Error).message,
+      cascade_trace: cascadeTrace,
     };
   }
 }

--- a/src/types/router.ts
+++ b/src/types/router.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { FormatSpec } from "./outcome.js";
+import type { CascadeTrace } from "../cascade-router/types.js";
 
 export const TaskStatus = z.enum(["RECEIVED", "CLASSIFIED", "DISPATCHED", "COMPLETED", "FAILED"]);
 export type TaskStatus = z.infer<typeof TaskStatus>;
@@ -32,5 +33,6 @@ export const TaskResult = z.object({
   cost_usd: z.number().nullable(),
   latency_ms: z.number().nullable(),
   error: z.string().nullable(),
+  cascade_trace: z.custom<CascadeTrace>().optional(),
 });
 export type TaskResult = z.infer<typeof TaskResult>;

--- a/src/types/router.ts
+++ b/src/types/router.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { FormatSpec } from "./outcome.js";
-import type { CascadeTrace } from "../cascade-router/types.js";
+import { CascadeTraceSchema } from "../cascade-router/types.js";
 
 export const TaskStatus = z.enum(["RECEIVED", "CLASSIFIED", "DISPATCHED", "COMPLETED", "FAILED"]);
 export type TaskStatus = z.infer<typeof TaskStatus>;
@@ -33,6 +33,6 @@ export const TaskResult = z.object({
   cost_usd: z.number().nullable(),
   latency_ms: z.number().nullable(),
   error: z.string().nullable(),
-  cascade_trace: z.custom<CascadeTrace>().optional(),
+  cascade_trace: CascadeTraceSchema.optional(),
 });
 export type TaskResult = z.infer<typeof TaskResult>;

--- a/src/types/task.ts
+++ b/src/types/task.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { createHash } from "node:crypto";
+import type { CascadeTrace } from "../cascade-router/types.js";
 
 // --- UUIDv7 generation ---
 
@@ -39,5 +40,6 @@ export const TaskClassification = z.object({
   prompt_hash: z.string(),
   routing_confidence: z.number().optional(),
   routing_layer: z.string().optional(),
+  cascade_trace: z.custom<CascadeTrace>().optional(),
 });
 export type TaskClassification = z.infer<typeof TaskClassification>;

--- a/src/types/task.ts
+++ b/src/types/task.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { createHash } from "node:crypto";
-import type { CascadeTrace } from "../cascade-router/types.js";
+import { CascadeTraceSchema } from "../cascade-router/types.js";
 
 // --- UUIDv7 generation ---
 
@@ -40,6 +40,6 @@ export const TaskClassification = z.object({
   prompt_hash: z.string(),
   routing_confidence: z.number().optional(),
   routing_layer: z.string().optional(),
-  cascade_trace: z.custom<CascadeTrace>().optional(),
+  cascade_trace: CascadeTraceSchema.optional(),
 });
 export type TaskClassification = z.infer<typeof TaskClassification>;

--- a/tests/api/tasks.test.ts
+++ b/tests/api/tasks.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeAll, afterAll, afterEach, vi } from "vitest";
 import { createPool, getPool, query, destroy } from "../../src/db/connection.js";
+import { uuidv7 } from "../../src/types/task.js";
 import { loadConfig } from "../../src/config.js";
 import { runMigrations } from "../../src/db/migrate.js";
 import { createApp } from "../../src/api/app.js";
@@ -97,6 +98,7 @@ afterEach(() => {
 afterAll(async () => {
   if (doltAvailable) {
     const pool = getPool();
+    await pool.query("DELETE FROM routing_log WHERE input_text LIKE '%trace test%'");
     await pool.query("DELETE FROM execution_log WHERE agent_id LIKE 'api-task-%'");
     await pool.query("DELETE FROM task_log WHERE selected_agent_id LIKE 'api-task-%'");
     // Re-enable seed agents
@@ -167,6 +169,110 @@ describe("GET /tasks/:id", () => {
     if (!doltAvailable) skip();
 
     const res = await app.request("/tasks/non-existent-task-id");
+    expect(res.status).toBe(404);
+  });
+});
+
+describe("GET /tasks/:id/trace", () => {
+  it("returns cascade trace for completed task", async ({ skip }) => {
+    if (!doltAvailable) skip();
+    mockFetchSuccess("Trace test result");
+
+    const createRes = await app.request("/tasks", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ prompt: "Summarize this article for trace test" }),
+    });
+    const created = await createRes.json();
+
+    // Seed a routing_log entry with cascade_trace metadata for this task
+    const cascadeTrace = {
+      layers: [
+        {
+          layer: "deterministic",
+          status: "missed",
+          confidence: null,
+          similarity_score: null,
+          tier: null,
+          reason: "no rule matched",
+          latency_ms: 1,
+        },
+        {
+          layer: "semantic",
+          status: "matched",
+          confidence: 0.88,
+          similarity_score: 0.91,
+          tier: 2,
+          reason: "top-k hit",
+          latency_ms: 12,
+        },
+        {
+          layer: "escalation",
+          status: "skipped",
+          confidence: null,
+          similarity_score: null,
+          tier: null,
+          reason: "already resolved",
+          latency_ms: 0,
+        },
+        {
+          layer: "fallback",
+          status: "skipped",
+          confidence: null,
+          similarity_score: null,
+          tier: null,
+          reason: "already resolved",
+          latency_ms: 0,
+        },
+      ],
+      resolved_layer: "semantic",
+      total_latency_ms: 13,
+    };
+    const pool = getPool();
+    await pool.query(
+      `INSERT INTO routing_log
+         (log_id, request_id, input_text, routed_tier, routing_layer, similarity_score, confidence, latency_ms, metadata)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      [
+        uuidv7(),
+        created.task_id,
+        "Summarize this article for trace test",
+        2,
+        "semantic",
+        0.91,
+        0.88,
+        13,
+        JSON.stringify({ cascade_trace: cascadeTrace }),
+      ],
+    );
+
+    const res = await app.request(`/tasks/${created.task_id}/trace`);
+    expect(res.status).toBe(200);
+
+    const trace = await res.json();
+    expect(trace.layers).toHaveLength(4);
+    expect(trace.resolved_layer).toBeDefined();
+    expect(typeof trace.total_latency_ms).toBe("number");
+
+    // Verify layer order
+    expect(trace.layers.map((l: any) => l.layer)).toEqual([
+      "deterministic",
+      "semantic",
+      "escalation",
+      "fallback",
+    ]);
+
+    // Each layer has required fields
+    for (const attempt of trace.layers) {
+      expect(["matched", "missed", "skipped", "error"]).toContain(attempt.status);
+      expect(typeof attempt.reason).toBe("string");
+    }
+  });
+
+  it("returns 404 for non-existent task", async ({ skip }) => {
+    if (!doltAvailable) skip();
+
+    const res = await app.request("/tasks/non-existent-id/trace");
     expect(res.status).toBe(404);
   });
 });

--- a/tests/cascade-router/cascade-trace.test.ts
+++ b/tests/cascade-router/cascade-trace.test.ts
@@ -104,8 +104,8 @@ function expectTraceShape(trace: CascadeTrace) {
 
   // Exactly one layer should be the resolved layer
   const matched = trace.layers.filter((l) => l.status === "matched");
-  expect(matched.length).toBeGreaterThanOrEqual(1);
-  expect(matched.some((l) => l.layer === trace.resolved_layer)).toBe(true);
+  expect(matched).toHaveLength(1);
+  expect(matched[0].layer).toBe(trace.resolved_layer);
 }
 
 describe("CascadeTrace", () => {

--- a/tests/cascade-router/cascade-trace.test.ts
+++ b/tests/cascade-router/cascade-trace.test.ts
@@ -1,0 +1,400 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { CascadeRouter } from "../../src/cascade-router/cascade-router.js";
+import type {
+  EmbeddingProvider,
+  EscalationProvider,
+  TierId,
+  LayerAttempt,
+  CascadeTrace,
+} from "../../src/cascade-router/types.js";
+
+// Mock DB layer
+vi.mock("../../src/cascade-router/reference-store.js", () => ({
+  loadRules: vi.fn(),
+  loadUtterances: vi.fn(),
+  loadConfig: vi.fn(),
+  logDecision: vi.fn().mockResolvedValue(undefined),
+  hasEmbeddings: vi.fn().mockResolvedValue(false),
+}));
+
+vi.mock("../../src/db/connection.js", () => ({
+  query: vi.fn().mockResolvedValue([
+    { tier_id: 1, tier_name: "Simple", description: "Basic tasks", default_agent: "local-llama" },
+    {
+      tier_id: 2,
+      tier_name: "Moderate",
+      description: "Moderate tasks",
+      default_agent: "gpt-4o-mini",
+    },
+    {
+      tier_id: 3,
+      tier_name: "Complex",
+      description: "Complex tasks",
+      default_agent: "claude-sonnet-4-5",
+    },
+    {
+      tier_id: 4,
+      tier_name: "Expert",
+      description: "Expert tasks",
+      default_agent: "claude-sonnet-4-5",
+    },
+  ]),
+  execute: vi.fn(),
+}));
+
+import * as store from "../../src/cascade-router/reference-store.js";
+
+const mockLoadRules = vi.mocked(store.loadRules);
+const mockLoadUtterances = vi.mocked(store.loadUtterances);
+const mockLoadConfig = vi.mocked(store.loadConfig);
+const mockLogDecision = vi.mocked(store.logDecision);
+
+const defaultConfig = {
+  embedding_model: "text-embedding-3-small",
+  embedding_dimensions: 512,
+  similarity_threshold: 0.72,
+  escalation_threshold: 0.55,
+  escalation_model: "claude-haiku-4-5-20251001",
+  default_tier: 3 as TierId,
+  top_k: 5,
+  enable_escalation: true,
+  confidence_threshold: 0.6,
+};
+
+function mockEmbedder(embedding: number[]): EmbeddingProvider {
+  return {
+    embed: vi.fn().mockResolvedValue(embedding),
+    modelId: () => "test-model",
+    dimensions: () => embedding.length,
+  };
+}
+
+function mockEscalation(
+  tier: TierId,
+  capabilities: string[] = [],
+  confidence = 0.8,
+): EscalationProvider {
+  return {
+    classify: vi.fn().mockResolvedValue({ tier, capabilities, confidence }),
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockLoadConfig.mockResolvedValue(defaultConfig);
+});
+
+function expectTraceShape(trace: CascadeTrace) {
+  expect(trace).toBeDefined();
+  expect(trace.layers).toHaveLength(4);
+  expect(trace.layers.map((l) => l.layer)).toEqual([
+    "deterministic",
+    "semantic",
+    "escalation",
+    "fallback",
+  ]);
+  expect(typeof trace.total_latency_ms).toBe("number");
+  expect(trace.total_latency_ms).toBeGreaterThanOrEqual(0);
+
+  for (const attempt of trace.layers) {
+    expect(["matched", "missed", "skipped", "error"]).toContain(attempt.status);
+    expect(typeof attempt.reason).toBe("string");
+    expect(attempt.reason.length).toBeGreaterThan(0);
+  }
+
+  // Exactly one layer should be the resolved layer
+  const matched = trace.layers.filter((l) => l.status === "matched");
+  expect(matched.length).toBeGreaterThanOrEqual(1);
+  expect(matched.some((l) => l.layer === trace.resolved_layer)).toBe(true);
+}
+
+describe("CascadeTrace", () => {
+  describe("trace shape", () => {
+    it("always contains all 4 layers in order", async () => {
+      mockLoadRules.mockResolvedValue([]);
+      mockLoadUtterances.mockResolvedValue([]);
+      mockLoadConfig.mockResolvedValue({ ...defaultConfig, enable_escalation: false });
+
+      const router = await CascadeRouter.create();
+      const result = await router.classify({ prompt: "Hello world" });
+
+      expectTraceShape(result.cascade_trace!);
+    });
+
+    it("attaches trace to TaskClassification", async () => {
+      mockLoadRules.mockResolvedValue([]);
+      mockLoadUtterances.mockResolvedValue([]);
+
+      const router = await CascadeRouter.create();
+      const result = await router.classify({ prompt: "Hello" });
+
+      expect(result.cascade_trace).toBeDefined();
+      expect(result.cascade_trace!.resolved_layer).toBeDefined();
+    });
+  });
+
+  describe("metadata override trace", () => {
+    it("shows deterministic matched, rest skipped", async () => {
+      mockLoadRules.mockResolvedValue([]);
+      mockLoadUtterances.mockResolvedValue([]);
+
+      const router = await CascadeRouter.create();
+      const result = await router.classify({
+        prompt: "Hello",
+        metadata: { tier: 2 },
+      });
+
+      const trace = result.cascade_trace!;
+      expectTraceShape(trace);
+      expect(trace.resolved_layer).toBe("deterministic");
+      expect(trace.layers[0].status).toBe("matched");
+      expect(trace.layers[0].tier).toBe(2);
+      expect(trace.layers[0].reason).toContain("metadata");
+      expect(trace.layers[1].status).toBe("skipped");
+      expect(trace.layers[2].status).toBe("skipped");
+      expect(trace.layers[3].status).toBe("skipped");
+    });
+  });
+
+  describe("deterministic layer trace", () => {
+    it("shows deterministic matched when rule hits", async () => {
+      mockLoadRules.mockResolvedValue([
+        {
+          rule_id: "r1",
+          tier_id: 2 as TierId,
+          rule_type: "contains",
+          pattern: "json",
+          capabilities: ["structured_output"],
+          priority: 10,
+          enabled: true,
+          description: null,
+        },
+      ]);
+      mockLoadUtterances.mockResolvedValue([]);
+
+      const router = await CascadeRouter.create();
+      const result = await router.classify({ prompt: "Format as json" });
+
+      const trace = result.cascade_trace!;
+      expectTraceShape(trace);
+      expect(trace.resolved_layer).toBe("deterministic");
+      expect(trace.layers[0].status).toBe("matched");
+      expect(trace.layers[0].confidence).toBe(1.0);
+      expect(trace.layers[0].tier).toBe(2);
+      expect(trace.layers[0].latency_ms).toBeGreaterThanOrEqual(0);
+    });
+
+    it("shows deterministic missed when no rules match", async () => {
+      mockLoadRules.mockResolvedValue([]);
+      mockLoadUtterances.mockResolvedValue([]);
+      mockLoadConfig.mockResolvedValue({ ...defaultConfig, enable_escalation: false });
+
+      const router = await CascadeRouter.create();
+      const result = await router.classify({ prompt: "Hello world" });
+
+      const trace = result.cascade_trace!;
+      expect(trace.layers[0].status).toBe("missed");
+      expect(trace.layers[0].confidence).toBeNull();
+      expect(trace.layers[0].tier).toBeNull();
+      expect(trace.layers[0].reason).toBe("no rules matched");
+    });
+  });
+
+  describe("semantic layer trace", () => {
+    it("shows semantic matched when confidence exceeds threshold", async () => {
+      mockLoadRules.mockResolvedValue([]);
+      mockLoadUtterances.mockResolvedValue([
+        { utterance_id: "u1", tier_id: 2 as TierId, utterance_text: "test", embedding: [1, 0, 0] },
+        {
+          utterance_id: "u2",
+          tier_id: 2 as TierId,
+          utterance_text: "test2",
+          embedding: [0.9, 0.1, 0],
+        },
+      ]);
+
+      const embedder = mockEmbedder([1, 0, 0]);
+      const router = await CascadeRouter.create({ embeddingProvider: embedder });
+      const result = await router.classify({ prompt: "some query" });
+
+      const trace = result.cascade_trace!;
+      expectTraceShape(trace);
+      expect(trace.resolved_layer).toBe("semantic");
+      expect(trace.layers[0].status).toBe("missed");
+      expect(trace.layers[1].status).toBe("matched");
+      expect(trace.layers[1].confidence).toBeGreaterThanOrEqual(0.72);
+      expect(trace.layers[1].similarity_score).not.toBeNull();
+      expect(trace.layers[2].status).toBe("skipped");
+      expect(trace.layers[3].status).toBe("skipped");
+    });
+
+    it("shows semantic missed when confidence below threshold", async () => {
+      mockLoadRules.mockResolvedValue([]);
+      mockLoadUtterances.mockResolvedValue([
+        { utterance_id: "u1", tier_id: 1 as TierId, utterance_text: "test1", embedding: [1, 0, 0] },
+        { utterance_id: "u2", tier_id: 2 as TierId, utterance_text: "test2", embedding: [0, 1, 0] },
+        { utterance_id: "u3", tier_id: 3 as TierId, utterance_text: "test3", embedding: [0, 0, 1] },
+      ]);
+
+      const embedder = mockEmbedder([0.577, 0.577, 0.577]);
+      const escalation = mockEscalation(4 as TierId, [], 0.9);
+      const router = await CascadeRouter.create({
+        embeddingProvider: embedder,
+        escalationProvider: escalation,
+      });
+      const result = await router.classify({ prompt: "ambiguous" });
+
+      const trace = result.cascade_trace!;
+      expect(trace.layers[1].status).toBe("missed");
+      expect(trace.layers[1].reason).toContain("< threshold");
+    });
+
+    it("shows semantic skipped when no utterances", async () => {
+      mockLoadRules.mockResolvedValue([]);
+      mockLoadUtterances.mockResolvedValue([]);
+      mockLoadConfig.mockResolvedValue({ ...defaultConfig, enable_escalation: false });
+
+      const router = await CascadeRouter.create();
+      const result = await router.classify({ prompt: "Hello" });
+
+      const trace = result.cascade_trace!;
+      expect(trace.layers[1].status).toBe("skipped");
+      expect(trace.layers[1].reason).toContain("no reference utterances");
+    });
+  });
+
+  describe("escalation layer trace", () => {
+    it("shows escalation matched after semantic miss", async () => {
+      mockLoadRules.mockResolvedValue([]);
+      mockLoadUtterances.mockResolvedValue([
+        { utterance_id: "u1", tier_id: 1 as TierId, utterance_text: "test", embedding: [1, 0, 0] },
+        { utterance_id: "u2", tier_id: 2 as TierId, utterance_text: "test2", embedding: [0, 1, 0] },
+        { utterance_id: "u3", tier_id: 3 as TierId, utterance_text: "test3", embedding: [0, 0, 1] },
+      ]);
+
+      const embedder = mockEmbedder([0.577, 0.577, 0.577]);
+      const escalation = mockEscalation(4 as TierId, ["vision"], 0.85);
+      const router = await CascadeRouter.create({
+        embeddingProvider: embedder,
+        escalationProvider: escalation,
+      });
+      const result = await router.classify({ prompt: "complex task" });
+
+      const trace = result.cascade_trace!;
+      expectTraceShape(trace);
+      expect(trace.resolved_layer).toBe("escalation");
+      expect(trace.layers[0].status).toBe("missed");
+      expect(trace.layers[1].status).toBe("missed");
+      expect(trace.layers[2].status).toBe("matched");
+      expect(trace.layers[2].confidence).toBe(0.85);
+      expect(trace.layers[2].tier).toBe(4);
+      expect(trace.layers[3].status).toBe("skipped");
+    });
+
+    it("shows escalation skipped when disabled", async () => {
+      mockLoadConfig.mockResolvedValue({ ...defaultConfig, enable_escalation: false });
+      mockLoadRules.mockResolvedValue([]);
+      mockLoadUtterances.mockResolvedValue([
+        { utterance_id: "u1", tier_id: 1 as TierId, utterance_text: "test", embedding: [1, 0, 0] },
+      ]);
+
+      const embedder = mockEmbedder([0, 1, 0]);
+      const router = await CascadeRouter.create({ embeddingProvider: embedder });
+      const result = await router.classify({ prompt: "something" });
+
+      const trace = result.cascade_trace!;
+      expect(trace.layers[2].status).toBe("skipped");
+      expect(trace.layers[2].reason).toContain("escalation disabled");
+    });
+
+    it("shows escalation error when provider throws", async () => {
+      mockLoadRules.mockResolvedValue([]);
+      mockLoadUtterances.mockResolvedValue([
+        { utterance_id: "u1", tier_id: 1 as TierId, utterance_text: "test", embedding: [1, 0, 0] },
+        { utterance_id: "u2", tier_id: 2 as TierId, utterance_text: "test2", embedding: [0, 1, 0] },
+      ]);
+
+      const embedder = mockEmbedder([0.577, 0.577, 0.577]);
+      const escalation: EscalationProvider = {
+        classify: vi.fn().mockRejectedValue(new Error("API timeout")),
+      };
+      const router = await CascadeRouter.create({
+        embeddingProvider: embedder,
+        escalationProvider: escalation,
+      });
+      const result = await router.classify({ prompt: "something" });
+
+      const trace = result.cascade_trace!;
+      expect(trace.layers[2].status).toBe("error");
+      expect(trace.layers[2].reason).toContain("API timeout");
+    });
+  });
+
+  describe("fallback layer trace", () => {
+    it("shows fallback matched when all layers fail", async () => {
+      mockLoadRules.mockResolvedValue([]);
+      mockLoadUtterances.mockResolvedValue([
+        { utterance_id: "u1", tier_id: 1 as TierId, utterance_text: "test", embedding: [1, 0, 0] },
+        { utterance_id: "u2", tier_id: 2 as TierId, utterance_text: "test2", embedding: [0, 1, 0] },
+      ]);
+
+      const embedder = mockEmbedder([0.577, 0.577, 0.577]);
+      const escalation: EscalationProvider = {
+        classify: vi.fn().mockRejectedValue(new Error("fail")),
+      };
+      const router = await CascadeRouter.create({
+        embeddingProvider: embedder,
+        escalationProvider: escalation,
+      });
+      const result = await router.classify({ prompt: "something" });
+
+      const trace = result.cascade_trace!;
+      expectTraceShape(trace);
+      expect(trace.resolved_layer).toBe("fallback");
+      expect(trace.layers[0].status).toBe("missed");
+      expect(trace.layers[1].status).toBe("missed");
+      expect(trace.layers[2].status).toBe("error");
+      expect(trace.layers[3].status).toBe("matched");
+      expect(trace.layers[3].tier).toBe(3);
+      expect(trace.layers[3].reason).toContain("T3");
+    });
+  });
+
+  describe("trace in logDecision metadata", () => {
+    it("passes cascade_trace in metadata to logDecision", async () => {
+      mockLoadRules.mockResolvedValue([]);
+      mockLoadUtterances.mockResolvedValue([]);
+      mockLoadConfig.mockResolvedValue({ ...defaultConfig, enable_escalation: false });
+
+      const router = await CascadeRouter.create();
+      await router.classify({ prompt: "Hello" });
+
+      expect(mockLogDecision).toHaveBeenCalledOnce();
+      const metadataArg = mockLogDecision.mock.calls[0][7];
+      expect(metadataArg).toBeDefined();
+      expect(metadataArg!.cascade_trace).toBeDefined();
+      const trace = metadataArg!.cascade_trace as CascadeTrace;
+      expect(trace.layers).toHaveLength(4);
+    });
+  });
+});
+
+describe("Legacy classifier trace", () => {
+  it("produces a trace with deterministic matched and rest skipped", async () => {
+    const { classify } = await import("../../src/classifier/classifier.js");
+    const result = classify({ prompt: "Summarize this text" });
+
+    const trace = result.cascade_trace!;
+    expect(trace).toBeDefined();
+    expect(trace.layers).toHaveLength(4);
+    expect(trace.resolved_layer).toBe("deterministic");
+    expect(trace.layers[0].status).toBe("matched");
+    expect(trace.layers[0].layer).toBe("deterministic");
+    expect(trace.layers[0].confidence).toBe(1.0);
+    expect(trace.layers[0].reason).toContain("legacy");
+    expect(trace.layers[1].status).toBe("skipped");
+    expect(trace.layers[2].status).toBe("skipped");
+    expect(trace.layers[3].status).toBe("skipped");
+    expect(trace.total_latency_ms).toBeGreaterThanOrEqual(0);
+  });
+});

--- a/tests/cascade-router/reference-store.test.ts
+++ b/tests/cascade-router/reference-store.test.ts
@@ -1,5 +1,10 @@
-import { describe, it, expect, beforeAll, afterAll, beforeEach } from "vitest";
-import { clearConfigCache, safeParseThreshold } from "../../src/cascade-router/reference-store.js";
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach, vi } from "vitest";
+import {
+  clearConfigCache,
+  safeParseThreshold,
+  findTraceByTaskId,
+} from "../../src/cascade-router/reference-store.js";
+import * as connectionModule from "../../src/db/connection.js";
 import { createPool, getPool, destroy } from "../../src/db/connection.js";
 import { loadConfig } from "../../src/config.js";
 import { runMigrations } from "../../src/db/migrate.js";
@@ -111,5 +116,98 @@ describe("safeParseThreshold", () => {
     expect(safeParseThreshold("1.5", 0.6)).toBe(1);
     expect(safeParseThreshold("-0.1", 0.6)).toBe(0);
     expect(safeParseThreshold("2.0", 0.6)).toBe(1);
+  });
+});
+
+describe("findTraceByTaskId", () => {
+  const validTrace = {
+    cascade_trace: {
+      layers: [
+        {
+          layer: "deterministic",
+          status: "missed",
+          confidence: null,
+          similarity_score: null,
+          tier: null,
+          reason: "no rule matched",
+          latency_ms: 2,
+        },
+        {
+          layer: "semantic",
+          status: "matched",
+          confidence: 0.88,
+          similarity_score: 0.91,
+          tier: 2,
+          reason: "top-k hit",
+          latency_ms: 15,
+        },
+        {
+          layer: "escalation",
+          status: "skipped",
+          confidence: null,
+          similarity_score: null,
+          tier: null,
+          reason: "already resolved",
+          latency_ms: 0,
+        },
+        {
+          layer: "fallback",
+          status: "skipped",
+          confidence: null,
+          similarity_score: null,
+          tier: null,
+          reason: "already resolved",
+          latency_ms: 0,
+        },
+      ],
+      resolved_layer: "semantic",
+      total_latency_ms: 17,
+    },
+  };
+
+  let querySpy: ReturnType<typeof vi.spyOn>;
+
+  afterEach(() => {
+    querySpy?.mockRestore();
+  });
+
+  it("returns null when no routing_log row exists", async () => {
+    querySpy = vi.spyOn(connectionModule, "query").mockResolvedValue([] as any);
+    const result = await findTraceByTaskId("no-such-task");
+    expect(result).toBeNull();
+  });
+
+  it("returns null when metadata is null", async () => {
+    querySpy = vi.spyOn(connectionModule, "query").mockResolvedValue([{ metadata: null }] as any);
+    const result = await findTraceByTaskId("task-null-meta");
+    expect(result).toBeNull();
+  });
+
+  it("returns null when metadata JSON is malformed", async () => {
+    querySpy = vi
+      .spyOn(connectionModule, "query")
+      .mockResolvedValue([{ metadata: "{not valid json!!" }] as any);
+    const result = await findTraceByTaskId("task-bad-json");
+    expect(result).toBeNull();
+  });
+
+  it("returns null when cascade_trace key is absent from metadata", async () => {
+    querySpy = vi
+      .spyOn(connectionModule, "query")
+      .mockResolvedValue([{ metadata: JSON.stringify({ other_key: "value" }) }] as any);
+    const result = await findTraceByTaskId("task-no-trace");
+    expect(result).toBeNull();
+  });
+
+  it("returns the trace when valid cascade_trace exists in metadata", async () => {
+    querySpy = vi
+      .spyOn(connectionModule, "query")
+      .mockResolvedValue([{ metadata: JSON.stringify(validTrace) }] as any);
+    const result = await findTraceByTaskId("task-with-trace");
+
+    expect(result).not.toBeNull();
+    expect(result!.layers).toHaveLength(4);
+    expect(result!.resolved_layer).toBe("semantic");
+    expect(result!.total_latency_ms).toBe(17);
   });
 });


### PR DESCRIPTION
## Summary
- Instrument the cascade router to record every layer attempt (matched, missed, skipped, error) with confidence, latency, and human-readable reason
- Return `cascade_trace` inline on `POST /tasks` responses for immediate demo visibility
- Add `GET /tasks/:id/trace` endpoint for retrospective trace inspection from `routing_log` metadata
- Legacy classifier also produces a trace for consistency when cascade router is unavailable

## Test plan
- [x] 14 new unit tests covering trace shape, all 4 layer statuses, metadata override, logDecision metadata passthrough, and legacy classifier trace
- [x] Full integration suite passes with Dolt (334 passed, 6 skipped)
- [x] Zero regressions on existing 46 cascade-router + classifier tests
- [ ] Manual verification: `curl POST /tasks` returns `cascade_trace` with layer attempts
- [ ] Manual verification: `GET /tasks/:id/trace` returns persisted trace