### PR TITLE
Add /observability/cascade endpoints for routing-brain telemetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -457,6 +457,48 @@ curl http://localhost:3000/stats/outcomes?hours=24
 curl http://localhost:3000/stats/routing-accuracy?hours=24
 ```
 
+### Cascade router observability
+
+Two endpoints aggregate `routing_log` so you can see how the cascade is performing in production traffic — and use that data to tune `similarity_threshold`, `escalation_threshold`, and `confidence_threshold` instead of guessing at them.
+
+```bash
+# Snapshot: layer hit-rate, tier distribution, latency p50/p95/p99,
+# confidence/similarity distributions, and the top 20 near-misses
+# (decisions where the semantic layer was consulted but did not resolve,
+# sorted by similarity_score DESC — these are the most informative for
+# tuning similarity_threshold).
+curl http://localhost:3000/observability/cascade?hours=24
+
+# Time-series: bucketed escalation_rate, fallback_rate, total volume,
+# and avg_latency_ms over time. bucket=hour (default) or bucket=day.
+curl http://localhost:3000/observability/cascade/timeseries?hours=72&bucket=hour
+```
+
+Snapshot response shape:
+
+```json
+{
+  "window_hours": 24,
+  "total_decisions": 1234,
+  "by_layer": {
+    "deterministic": { "count": 800, "share": 0.6483 },
+    "semantic":      { "count": 300, "share": 0.2431 },
+    "escalation":    { "count": 100, "share": 0.0810 },
+    "fallback":      { "count": 34,  "share": 0.0276 }
+  },
+  "by_tier":  { "1": { "count": 250, "share": 0.20 }, "2": { ... }, ... },
+  "latency_ms":          { "p50": 12, "p95": 180, "p99": 450, "max": 1200 },
+  "latency_by_layer_ms": { "deterministic": { ... }, "semantic": { ... }, ... },
+  "confidence":          { "p50": 0.78, "p95": 0.95, "p99": 0.99, "max": 1.0 },
+  "similarity_score":    { "p50": 0.71, "p95": 0.86, "p99": 0.91, "max": 0.94 },
+  "near_misses":         [ { "input_text": "...", "similarity_score": 0.71, ... } ],
+  "sample_size": 1234,
+  "sample_truncated": false
+}
+```
+
+Pairs naturally with `npm run load-test`: the load test catches routing regressions in synthetic runs, the cascade endpoints catch them in real traffic.
+
 ---
 
 ## Routing Tuner: Closing the Learning Loop

--- a/README.md
+++ b/README.md
@@ -472,6 +472,12 @@ curl http://localhost:3000/observability/cascade?hours=24
 # Time-series: bucketed escalation_rate, fallback_rate, total volume,
 # and avg_latency_ms over time. bucket=hour (default) or bucket=day.
 curl http://localhost:3000/observability/cascade/timeseries?hours=72&bucket=hour
+
+# Near-misses include only a SHA-256 hash of the input prompt by default,
+# so observability access (which is auth-gated) doesn't double as a PII
+# firehose for whoever holds the API key. Pass include_text=true to opt
+# into raw prompt content for ad-hoc debugging.
+curl http://localhost:3000/observability/cascade?hours=24&include_text=true
 ```
 
 Snapshot response shape:
@@ -479,6 +485,8 @@ Snapshot response shape:
 ```json
 {
   "window_hours": 24,
+  "snapshot_at": "2026-05-02T11:42:00.000Z",
+  "consistency": "best_effort",
   "total_decisions": 1234,
   "by_layer": {
     "deterministic": { "count": 800, "share": 0.6483 },
@@ -491,11 +499,21 @@ Snapshot response shape:
   "latency_by_layer_ms": { "deterministic": { ... }, "semantic": { ... }, ... },
   "confidence":          { "p50": 0.78, "p95": 0.95, "p99": 0.99, "max": 1.0 },
   "similarity_score":    { "p50": 0.71, "p95": 0.86, "p99": 0.91, "max": 0.94 },
-  "near_misses":         [ { "input_text": "...", "similarity_score": 0.71, ... } ],
+  "near_misses": [
+    {
+      "input_text_sha256": "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
+      "similarity_score": 0.71,
+      "routed_tier": 3,
+      "routing_layer": "escalation",
+      "created_at": "2026-05-02T11:30:00.000Z"
+    }
+  ],
   "sample_size": 1234,
   "sample_truncated": false
 }
 ```
+
+`consistency: "best_effort"` is a deliberate signal: the four underlying queries fire concurrently on independent connections, so under heavy concurrent writes the counts and percentile distributions can briefly disagree by a handful of rows. Tolerable for monitoring; not suitable for accounting. Use `snapshot_at` to correlate with other systems.
 
 Pairs naturally with `npm run load-test`: the load test catches routing regressions in synthetic runs, the cascade endpoints catch them in real traffic.
 

--- a/src/api/routes/observability.ts
+++ b/src/api/routes/observability.ts
@@ -95,7 +95,10 @@ observability.get("/stats/orphaned-pending", async (c) => {
 
 observability.get("/cascade", async (c) => {
   const hours = parseIntParam(c.req.query("hours"), 24, 1, MAX_HOURS);
-  const data = await getCascadeSnapshot(hours);
+  // include_text=true opts into raw prompt content in near_misses. Default
+  // false so observability access doesn't double as a PII firehose.
+  const includeText = c.req.query("include_text") === "true";
+  const data = await getCascadeSnapshot(hours, { includeText });
   return c.json(data, 200);
 });
 

--- a/src/api/routes/observability.ts
+++ b/src/api/routes/observability.ts
@@ -12,6 +12,7 @@ import {
   costSavings,
 } from "../../observability/queries.js";
 import { getDashboard } from "../../observability/dashboard.js";
+import { getCascadeSnapshot, getCascadeTimeseries } from "../../observability/cascade.js";
 import {
   cleanupOrphanedPendingRecords,
   countOrphanedPendingRecords,
@@ -88,6 +89,27 @@ observability.get("/stats/orphaned-pending", async (c) => {
   const maxAgeHours = parseIntParam(c.req.query("max_age_hours"), 24, 1, MAX_HOURS);
   const count = await countOrphanedPendingRecords(maxAgeHours);
   return c.json({ orphaned_pending: count, max_age_hours: maxAgeHours }, 200);
+});
+
+// --- Cascade router routes ---
+
+observability.get("/cascade", async (c) => {
+  const hours = parseIntParam(c.req.query("hours"), 24, 1, MAX_HOURS);
+  const data = await getCascadeSnapshot(hours);
+  return c.json(data, 200);
+});
+
+observability.get("/cascade/timeseries", async (c) => {
+  const hours = parseIntParam(c.req.query("hours"), 24, 1, MAX_HOURS);
+  const bucketRaw = c.req.query("bucket") ?? "hour";
+  // Normalize bucket to a number of hours. Reject anything else with 400 so
+  // callers can't accidentally request unsupported bucket sizes.
+  const bucketHours = bucketRaw === "day" ? 24 : bucketRaw === "hour" ? 1 : null;
+  if (bucketHours === null) {
+    return c.json({ error: "bucket must be 'hour' or 'day'" }, 400);
+  }
+  const data = await getCascadeTimeseries(hours, bucketHours);
+  return c.json(data, 200);
 });
 
 // --- Maintenance routes ---

--- a/src/observability/cascade-queries.ts
+++ b/src/observability/cascade-queries.ts
@@ -1,0 +1,200 @@
+import { query } from "../db/connection.js";
+import type { RowDataPacket } from "mysql2/promise";
+
+// Thin SQL layer for cascade-router observability. All aggregation that
+// requires percentiles is done in the service layer (see ./cascade.ts) so
+// the queries stay portable across MySQL/Dolt versions and easy to test.
+
+export interface LayerCountRow {
+  layer: string;
+  count: number;
+}
+interface LayerCountRaw extends RowDataPacket {
+  routing_layer: string;
+  cnt: string | number;
+}
+
+export async function cascadeLayerCounts(hours: number): Promise<LayerCountRow[]> {
+  const rows = await query<LayerCountRaw[]>(
+    `SELECT routing_layer, COUNT(*) AS cnt
+     FROM routing_log
+     WHERE created_at >= DATE_SUB(NOW(), INTERVAL ? HOUR)
+     GROUP BY routing_layer`,
+    [hours],
+  );
+  return rows.map((r) => ({
+    layer: r.routing_layer,
+    count: typeof r.cnt === "string" ? parseInt(r.cnt, 10) : Number(r.cnt),
+  }));
+}
+
+export interface TierCountRow {
+  tier: number;
+  count: number;
+}
+interface TierCountRaw extends RowDataPacket {
+  routed_tier: number;
+  cnt: string | number;
+}
+
+export async function cascadeTierCounts(hours: number): Promise<TierCountRow[]> {
+  const rows = await query<TierCountRaw[]>(
+    `SELECT routed_tier, COUNT(*) AS cnt
+     FROM routing_log
+     WHERE created_at >= DATE_SUB(NOW(), INTERVAL ? HOUR)
+     GROUP BY routed_tier
+     ORDER BY routed_tier`,
+    [hours],
+  );
+  return rows.map((r) => ({
+    tier: Number(r.routed_tier),
+    count: typeof r.cnt === "string" ? parseInt(r.cnt, 10) : Number(r.cnt),
+  }));
+}
+
+export interface DecisionSampleRow {
+  layer: string;
+  latency_ms: number;
+  confidence: number | null;
+  similarity_score: number | null;
+}
+interface DecisionSampleRaw extends RowDataPacket {
+  routing_layer: string;
+  latency_ms: string | number;
+  confidence: string | number | null;
+  similarity_score: string | number | null;
+}
+
+/**
+ * Pull the raw decision samples needed to compute percentiles and
+ * distributions in the service layer. Bounded by `limit` so a wide window
+ * doesn't pull millions of rows.
+ */
+export async function cascadeDecisionSamples(
+  hours: number,
+  limit: number,
+): Promise<DecisionSampleRow[]> {
+  const rows = await query<DecisionSampleRaw[]>(
+    `SELECT routing_layer, latency_ms, confidence, similarity_score
+     FROM routing_log
+     WHERE created_at >= DATE_SUB(NOW(), INTERVAL ? HOUR)
+     ORDER BY created_at DESC
+     LIMIT ?`,
+    [hours, limit],
+  );
+  return rows.map((r) => ({
+    layer: r.routing_layer,
+    latency_ms: typeof r.latency_ms === "string" ? parseFloat(r.latency_ms) : Number(r.latency_ms),
+    confidence:
+      r.confidence === null
+        ? null
+        : typeof r.confidence === "string"
+          ? parseFloat(r.confidence)
+          : Number(r.confidence),
+    similarity_score:
+      r.similarity_score === null
+        ? null
+        : typeof r.similarity_score === "string"
+          ? parseFloat(r.similarity_score)
+          : Number(r.similarity_score),
+  }));
+}
+
+export interface NearMissRow {
+  input_text: string;
+  similarity_score: number;
+  routed_tier: number;
+  routing_layer: string;
+  created_at: string;
+}
+interface NearMissRaw extends RowDataPacket {
+  input_text: string;
+  similarity_score: string | number;
+  routed_tier: number;
+  routing_layer: string;
+  created_at: Date | string;
+}
+
+/**
+ * Decisions where the semantic layer was consulted but did not resolve —
+ * i.e., the cascade fell through to escalation or fallback. Sorted by
+ * similarity_score DESC because the highest-scoring near-misses are the
+ * most informative for tuning `similarity_threshold`.
+ */
+export async function cascadeNearMisses(hours: number, limit: number): Promise<NearMissRow[]> {
+  const rows = await query<NearMissRaw[]>(
+    `SELECT input_text, similarity_score, routed_tier, routing_layer, created_at
+     FROM routing_log
+     WHERE created_at >= DATE_SUB(NOW(), INTERVAL ? HOUR)
+       AND routing_layer IN ('escalation', 'fallback')
+       AND similarity_score IS NOT NULL
+     ORDER BY similarity_score DESC
+     LIMIT ?`,
+    [hours, limit],
+  );
+  return rows.map((r) => ({
+    input_text: r.input_text,
+    similarity_score:
+      typeof r.similarity_score === "string"
+        ? parseFloat(r.similarity_score)
+        : Number(r.similarity_score),
+    routed_tier: Number(r.routed_tier),
+    routing_layer: r.routing_layer,
+    created_at: r.created_at instanceof Date ? r.created_at.toISOString() : String(r.created_at),
+  }));
+}
+
+export interface TimeseriesRow {
+  bucket_start: string;
+  total: number;
+  escalations: number;
+  fallbacks: number;
+  avg_latency_ms: number;
+}
+interface TimeseriesRaw extends RowDataPacket {
+  bucket_start: Date | string;
+  total: string | number;
+  escalations: string | number;
+  fallbacks: string | number;
+  avg_latency_ms: string | number | null;
+}
+
+/**
+ * Bucketed counts for trending escalation rate and volume. `bucketHours`
+ * is the bucket width in hours (1 = hourly, 24 = daily).
+ */
+export async function cascadeTimeseries(
+  hours: number,
+  bucketHours: number,
+): Promise<TimeseriesRow[]> {
+  // Floor each row's created_at to the bucket boundary by computing
+  // FROM_UNIXTIME(FLOOR(UNIX_TIMESTAMP(created_at) / bucket_seconds) * bucket_seconds).
+  // Done in SQL so the bucket key is stable regardless of how many rows fall in.
+  const bucketSeconds = bucketHours * 3600;
+  const rows = await query<TimeseriesRaw[]>(
+    `SELECT FROM_UNIXTIME(FLOOR(UNIX_TIMESTAMP(created_at) / ?) * ?) AS bucket_start,
+            COUNT(*) AS total,
+            SUM(CASE WHEN routing_layer = 'escalation' THEN 1 ELSE 0 END) AS escalations,
+            SUM(CASE WHEN routing_layer = 'fallback' THEN 1 ELSE 0 END) AS fallbacks,
+            AVG(latency_ms) AS avg_latency_ms
+     FROM routing_log
+     WHERE created_at >= DATE_SUB(NOW(), INTERVAL ? HOUR)
+     GROUP BY bucket_start
+     ORDER BY bucket_start ASC`,
+    [bucketSeconds, bucketSeconds, hours],
+  );
+  return rows.map((r) => ({
+    bucket_start:
+      r.bucket_start instanceof Date ? r.bucket_start.toISOString() : String(r.bucket_start),
+    total: typeof r.total === "string" ? parseInt(r.total, 10) : Number(r.total),
+    escalations:
+      typeof r.escalations === "string" ? parseInt(r.escalations, 10) : Number(r.escalations),
+    fallbacks: typeof r.fallbacks === "string" ? parseInt(r.fallbacks, 10) : Number(r.fallbacks),
+    avg_latency_ms:
+      r.avg_latency_ms === null
+        ? 0
+        : typeof r.avg_latency_ms === "string"
+          ? parseFloat(r.avg_latency_ms)
+          : Number(r.avg_latency_ms),
+  }));
+}

--- a/src/observability/cascade.ts
+++ b/src/observability/cascade.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import {
   cascadeLayerCounts,
   cascadeTierCounts,
@@ -16,6 +17,16 @@ const NEAR_MISS_TEXT_MAX = 200;
 
 export interface CascadeSnapshot {
   window_hours: number;
+  // ISO8601 timestamp captured at the start of the snapshot. The four
+  // underlying queries fire concurrently on independent connections, so
+  // counts and percentile distributions reflect slightly different points
+  // in time under heavy concurrent writes — see `consistency` below.
+  snapshot_at: string;
+  // "best_effort" — counts and distributions are aggregated from
+  // independent queries and may briefly disagree by a handful of rows
+  // when new decisions are being inserted. Tolerable for monitoring;
+  // not suitable for accounting.
+  consistency: "best_effort";
   total_decisions: number;
   by_layer: Record<KnownLayer, { count: number; share: number }>;
   by_tier: Record<string, { count: number; share: number }>;
@@ -36,7 +47,15 @@ export interface PercentileBlock {
 }
 
 export interface NearMissEntry {
-  input_text: string;
+  // SHA-256 of the original input_text. Always present so consumers can
+  // dedupe identical near-misses across calls without ever seeing the
+  // prompt content.
+  input_text_sha256: string;
+  // Raw input prompt (truncated). Only populated when the caller passes
+  // includeText: true. Default omits it so that observability access
+  // (already auth-gated) doesn't double as a PII firehose for whoever
+  // holds the API key.
+  input_text?: string;
   similarity_score: number;
   routed_tier: number;
   routing_layer: string;
@@ -71,11 +90,16 @@ export function percentile(values: number[], p: number): number {
 
 export function percentileBlock(values: number[]): PercentileBlock {
   if (values.length === 0) return { p50: 0, p95: 0, p99: 0, max: 0 };
+  // reduce instead of Math.max(...values): the spread form throws on arrays
+  // larger than the engine's argument-count limit (~65k in V8). SAMPLE_LIMIT
+  // is well under that today, but reduce has no such ceiling.
+  let max = -Infinity;
+  for (const v of values) if (v > max) max = v;
   return {
     p50: round(percentile(values, 50)),
     p95: round(percentile(values, 95)),
     p99: round(percentile(values, 99)),
-    max: round(Math.max(...values)),
+    max: round(max),
   };
 }
 
@@ -146,7 +170,22 @@ function truncate(s: string, n: number): string {
 
 // ── Composed service entry points ───────────────────────────────
 
-export async function getCascadeSnapshot(hours: number): Promise<CascadeSnapshot> {
+export interface SnapshotOptions {
+  /**
+   * When true, near_misses includes the raw `input_text` (truncated to
+   * NEAR_MISS_TEXT_MAX). Default false — the SHA-256 is always returned
+   * so consumers can dedupe identical near-misses without seeing prompt
+   * content. Only enable for ad-hoc debugging; do not surface to
+   * dashboards or third-party integrations.
+   */
+  includeText?: boolean;
+}
+
+export async function getCascadeSnapshot(
+  hours: number,
+  opts: SnapshotOptions = {},
+): Promise<CascadeSnapshot> {
+  const snapshotAt = new Date().toISOString();
   const [layerRows, tierRows, samples, nearMisses] = await Promise.all([
     cascadeLayerCounts(hours),
     cascadeTierCounts(hours),
@@ -165,6 +204,8 @@ export async function getCascadeSnapshot(hours: number): Promise<CascadeSnapshot
 
   return {
     window_hours: hours,
+    snapshot_at: snapshotAt,
+    consistency: "best_effort",
     total_decisions: total,
     by_layer: byLayer,
     by_tier: byTier,
@@ -172,13 +213,24 @@ export async function getCascadeSnapshot(hours: number): Promise<CascadeSnapshot
     latency_by_layer_ms: latencyByLayer(samples),
     confidence: confidences.length === 0 ? null : percentileBlock(confidences),
     similarity_score: similarities.length === 0 ? null : percentileBlock(similarities),
-    near_misses: nearMisses.map((n) => ({
-      ...n,
-      input_text: truncate(n.input_text, NEAR_MISS_TEXT_MAX),
-    })),
+    near_misses: nearMisses.map((n) => {
+      const entry: NearMissEntry = {
+        input_text_sha256: sha256(n.input_text),
+        similarity_score: n.similarity_score,
+        routed_tier: n.routed_tier,
+        routing_layer: n.routing_layer,
+        created_at: n.created_at,
+      };
+      if (opts.includeText) entry.input_text = truncate(n.input_text, NEAR_MISS_TEXT_MAX);
+      return entry;
+    }),
     sample_size: samples.length,
     sample_truncated: samples.length >= SAMPLE_LIMIT,
   };
+}
+
+function sha256(s: string): string {
+  return createHash("sha256").update(s).digest("hex");
 }
 
 export async function getCascadeTimeseries(

--- a/src/observability/cascade.ts
+++ b/src/observability/cascade.ts
@@ -1,0 +1,202 @@
+import {
+  cascadeLayerCounts,
+  cascadeTierCounts,
+  cascadeDecisionSamples,
+  cascadeNearMisses,
+  cascadeTimeseries,
+  type DecisionSampleRow,
+} from "./cascade-queries.js";
+
+const KNOWN_LAYERS = ["deterministic", "semantic", "escalation", "fallback"] as const;
+type KnownLayer = (typeof KNOWN_LAYERS)[number];
+
+const SAMPLE_LIMIT = 10_000;
+const NEAR_MISS_LIMIT = 20;
+const NEAR_MISS_TEXT_MAX = 200;
+
+export interface CascadeSnapshot {
+  window_hours: number;
+  total_decisions: number;
+  by_layer: Record<KnownLayer, { count: number; share: number }>;
+  by_tier: Record<string, { count: number; share: number }>;
+  latency_ms: PercentileBlock;
+  latency_by_layer_ms: Partial<Record<KnownLayer, PercentileBlock>>;
+  confidence: PercentileBlock | null;
+  similarity_score: PercentileBlock | null;
+  near_misses: NearMissEntry[];
+  sample_size: number;
+  sample_truncated: boolean;
+}
+
+export interface PercentileBlock {
+  p50: number;
+  p95: number;
+  p99: number;
+  max: number;
+}
+
+export interface NearMissEntry {
+  input_text: string;
+  similarity_score: number;
+  routed_tier: number;
+  routing_layer: string;
+  created_at: string;
+}
+
+export interface CascadeTimeseriesEntry {
+  bucket_start: string;
+  total: number;
+  escalations: number;
+  fallbacks: number;
+  escalation_rate: number;
+  fallback_rate: number;
+  avg_latency_ms: number;
+}
+
+export interface CascadeTimeseriesResponse {
+  window_hours: number;
+  bucket_hours: number;
+  buckets: CascadeTimeseriesEntry[];
+}
+
+// ── Pure helpers ────────────────────────────────────────────────
+
+/** Nearest-rank percentile: same algorithm as load-test.ts so the two surfaces stay comparable. */
+export function percentile(values: number[], p: number): number {
+  if (values.length === 0) return 0;
+  const sorted = [...values].sort((a, b) => a - b);
+  const idx = Math.min(sorted.length - 1, Math.ceil((p / 100) * sorted.length) - 1);
+  return sorted[Math.max(0, idx)];
+}
+
+export function percentileBlock(values: number[]): PercentileBlock {
+  if (values.length === 0) return { p50: 0, p95: 0, p99: 0, max: 0 };
+  return {
+    p50: round(percentile(values, 50)),
+    p95: round(percentile(values, 95)),
+    p99: round(percentile(values, 99)),
+    max: round(Math.max(...values)),
+  };
+}
+
+/**
+ * Build the by-layer block, ensuring every known layer is present (with
+ * zero counts if absent). Callers want a stable shape they can chart
+ * without fear of missing keys.
+ */
+export function shareByLayer(rows: { layer: string; count: number }[]): {
+  total: number;
+  out: CascadeSnapshot["by_layer"];
+} {
+  const total = rows.reduce((s, r) => s + r.count, 0);
+  const out = Object.fromEntries(
+    KNOWN_LAYERS.map((l) => [l, { count: 0, share: 0 }]),
+  ) as CascadeSnapshot["by_layer"];
+  for (const r of rows) {
+    if (!isKnownLayer(r.layer)) continue;
+    out[r.layer] = {
+      count: r.count,
+      share: total === 0 ? 0 : round4(r.count / total),
+    };
+  }
+  return { total, out };
+}
+
+export function shareByTier(rows: { tier: number; count: number }[]): CascadeSnapshot["by_tier"] {
+  const total = rows.reduce((s, r) => s + r.count, 0);
+  const out: CascadeSnapshot["by_tier"] = {};
+  for (const r of rows) {
+    out[String(r.tier)] = {
+      count: r.count,
+      share: total === 0 ? 0 : round4(r.count / total),
+    };
+  }
+  return out;
+}
+
+export function latencyByLayer(
+  samples: DecisionSampleRow[],
+): CascadeSnapshot["latency_by_layer_ms"] {
+  const groups: Partial<Record<KnownLayer, number[]>> = {};
+  for (const s of samples) {
+    if (!isKnownLayer(s.layer)) continue;
+    (groups[s.layer] ??= []).push(s.latency_ms);
+  }
+  const out: CascadeSnapshot["latency_by_layer_ms"] = {};
+  for (const [layer, vals] of Object.entries(groups) as [KnownLayer, number[]][]) {
+    if (vals.length > 0) out[layer] = percentileBlock(vals);
+  }
+  return out;
+}
+
+function isKnownLayer(s: string): s is KnownLayer {
+  return (KNOWN_LAYERS as readonly string[]).includes(s);
+}
+
+function round(n: number): number {
+  return Math.round(n * 100) / 100;
+}
+function round4(n: number): number {
+  return Math.round(n * 10000) / 10000;
+}
+
+function truncate(s: string, n: number): string {
+  return s.length <= n ? s : s.slice(0, n) + "…";
+}
+
+// ── Composed service entry points ───────────────────────────────
+
+export async function getCascadeSnapshot(hours: number): Promise<CascadeSnapshot> {
+  const [layerRows, tierRows, samples, nearMisses] = await Promise.all([
+    cascadeLayerCounts(hours),
+    cascadeTierCounts(hours),
+    cascadeDecisionSamples(hours, SAMPLE_LIMIT),
+    cascadeNearMisses(hours, NEAR_MISS_LIMIT),
+  ]);
+
+  const { total, out: byLayer } = shareByLayer(layerRows);
+  const byTier = shareByTier(tierRows);
+
+  const latencies = samples.map((s) => s.latency_ms);
+  const confidences = samples.map((s) => s.confidence).filter((v): v is number => v !== null);
+  const similarities = samples
+    .map((s) => s.similarity_score)
+    .filter((v): v is number => v !== null);
+
+  return {
+    window_hours: hours,
+    total_decisions: total,
+    by_layer: byLayer,
+    by_tier: byTier,
+    latency_ms: percentileBlock(latencies),
+    latency_by_layer_ms: latencyByLayer(samples),
+    confidence: confidences.length === 0 ? null : percentileBlock(confidences),
+    similarity_score: similarities.length === 0 ? null : percentileBlock(similarities),
+    near_misses: nearMisses.map((n) => ({
+      ...n,
+      input_text: truncate(n.input_text, NEAR_MISS_TEXT_MAX),
+    })),
+    sample_size: samples.length,
+    sample_truncated: samples.length >= SAMPLE_LIMIT,
+  };
+}
+
+export async function getCascadeTimeseries(
+  hours: number,
+  bucketHours: number,
+): Promise<CascadeTimeseriesResponse> {
+  const rows = await cascadeTimeseries(hours, bucketHours);
+  return {
+    window_hours: hours,
+    bucket_hours: bucketHours,
+    buckets: rows.map((r) => ({
+      bucket_start: r.bucket_start,
+      total: r.total,
+      escalations: r.escalations,
+      fallbacks: r.fallbacks,
+      escalation_rate: r.total === 0 ? 0 : round4(r.escalations / r.total),
+      fallback_rate: r.total === 0 ? 0 : round4(r.fallbacks / r.total),
+      avg_latency_ms: round(r.avg_latency_ms),
+    })),
+  };
+}

--- a/tests/api/observability-cascade.test.ts
+++ b/tests/api/observability-cascade.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { createPool, getPool, query, destroy } from "../../src/db/connection.js";
+import { loadConfig } from "../../src/config.js";
+import { runMigrations } from "../../src/db/migrate.js";
+import { createApp } from "../../src/api/app.js";
+import { uuidv7 } from "../../src/types/task.js";
+import type { Hono } from "hono";
+
+let doltAvailable = false;
+let app: Hono;
+
+const TEST_PREFIX = "test-cascade-obs-";
+
+beforeAll(async () => {
+  const config = loadConfig();
+  try {
+    getPool();
+  } catch {
+    createPool(config.dolt);
+  }
+  try {
+    await query("SELECT 1");
+    // Only mark the suite as runnable once migrations succeed against a
+    // real `haol` database — `SELECT 1` succeeds even without a database
+    // selected, so the prior check is necessary but not sufficient.
+    await runMigrations();
+    doltAvailable = true;
+  } catch {
+    console.warn("Dolt + haol database not available — skipping cascade observability tests");
+  }
+  app = createApp();
+});
+
+afterAll(async () => {
+  if (doltAvailable) {
+    const pool = getPool();
+    // Tag test rows via request_id prefix so cleanup is precise.
+    await pool.query("DELETE FROM routing_log WHERE request_id LIKE ?", [`${TEST_PREFIX}%`]);
+  }
+  await destroy();
+});
+
+async function seedRoutingLog(
+  rows: Array<{
+    layer: string;
+    tier: number;
+    latency: number;
+    conf: number | null;
+    sim: number | null;
+  }>,
+) {
+  const pool = getPool();
+  for (const r of rows) {
+    await pool.query(
+      `INSERT INTO routing_log
+         (log_id, request_id, input_text, routed_tier, routing_layer, similarity_score, confidence, latency_ms, metadata)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, NULL)`,
+      [
+        uuidv7(),
+        `${TEST_PREFIX}${uuidv7()}`,
+        "test prompt",
+        r.tier,
+        r.layer,
+        r.sim,
+        r.conf,
+        r.latency,
+      ],
+    );
+  }
+}
+
+describe("GET /observability/cascade", () => {
+  it("returns the snapshot shape with zero-counts when no rows match", async ({ skip }) => {
+    if (!doltAvailable) skip();
+
+    // Use a 1-hour window after cleaning out test data so we can assert zeros.
+    const pool = getPool();
+    await pool.query("DELETE FROM routing_log WHERE request_id LIKE ?", [`${TEST_PREFIX}%`]);
+
+    const res = await app.request("/observability/cascade?hours=1");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body).toHaveProperty("window_hours", 1);
+    expect(body).toHaveProperty("total_decisions");
+    expect(body).toHaveProperty("by_layer");
+    const byLayer = body.by_layer as Record<string, unknown>;
+    expect(Object.keys(byLayer).sort()).toEqual([
+      "deterministic",
+      "escalation",
+      "fallback",
+      "semantic",
+    ]);
+    expect(body).toHaveProperty("by_tier");
+    expect(body).toHaveProperty("latency_ms");
+    expect(body).toHaveProperty("near_misses");
+    expect(Array.isArray(body.near_misses)).toBe(true);
+  });
+
+  it("aggregates seeded rows by layer", async ({ skip }) => {
+    if (!doltAvailable) skip();
+
+    const pool = getPool();
+    await pool.query("DELETE FROM routing_log WHERE request_id LIKE ?", [`${TEST_PREFIX}%`]);
+
+    await seedRoutingLog([
+      { layer: "deterministic", tier: 1, latency: 5, conf: 1.0, sim: null },
+      { layer: "deterministic", tier: 1, latency: 6, conf: 1.0, sim: null },
+      { layer: "semantic", tier: 2, latency: 80, conf: 0.78, sim: 0.74 },
+      { layer: "escalation", tier: 3, latency: 450, conf: 0.85, sim: 0.4 },
+      { layer: "fallback", tier: 3, latency: 0, conf: 0, sim: null },
+    ]);
+
+    const res = await app.request("/observability/cascade?hours=1");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      total_decisions: number;
+      by_layer: Record<string, { count: number; share: number }>;
+      by_tier: Record<string, { count: number }>;
+      near_misses: Array<{ similarity_score: number; routing_layer: string }>;
+    };
+
+    expect(body.total_decisions).toBe(5);
+    expect(body.by_layer.deterministic.count).toBe(2);
+    expect(body.by_layer.semantic.count).toBe(1);
+    expect(body.by_layer.escalation.count).toBe(1);
+    expect(body.by_layer.fallback.count).toBe(1);
+
+    expect(body.by_tier["1"].count).toBe(2);
+    expect(body.by_tier["3"].count).toBe(2);
+
+    // Near-misses include only escalation/fallback rows with a non-null
+    // similarity_score — only the seeded escalation row qualifies.
+    expect(body.near_misses.length).toBe(1);
+    expect(body.near_misses[0].similarity_score).toBeCloseTo(0.4);
+    expect(body.near_misses[0].routing_layer).toBe("escalation");
+  });
+
+  it("clamps the hours parameter to the valid range", async ({ skip }) => {
+    if (!doltAvailable) skip();
+    const res = await app.request("/observability/cascade?hours=999999999");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { window_hours: number };
+    expect(body.window_hours).toBe(8760); // MAX_HOURS
+  });
+});
+
+describe("GET /observability/cascade/timeseries", () => {
+  it("returns hourly buckets by default", async ({ skip }) => {
+    if (!doltAvailable) skip();
+    const res = await app.request("/observability/cascade/timeseries?hours=1");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { bucket_hours: number; buckets: unknown[] };
+    expect(body.bucket_hours).toBe(1);
+    expect(Array.isArray(body.buckets)).toBe(true);
+  });
+
+  it("accepts bucket=day", async ({ skip }) => {
+    if (!doltAvailable) skip();
+    const res = await app.request("/observability/cascade/timeseries?hours=24&bucket=day");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { bucket_hours: number };
+    expect(body.bucket_hours).toBe(24);
+  });
+
+  it("rejects unsupported bucket values with 400", async ({ skip }) => {
+    if (!doltAvailable) skip();
+    const res = await app.request("/observability/cascade/timeseries?bucket=minute");
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toMatch(/bucket/);
+  });
+});

--- a/tests/api/observability-cascade.test.ts
+++ b/tests/api/observability-cascade.test.ts
@@ -9,7 +9,9 @@ import type { Hono } from "hono";
 let doltAvailable = false;
 let app: Hono;
 
-const TEST_PREFIX = "test-cascade-obs-";
+// Tag test rows via input_text instead of request_id, since request_id is
+// VARCHAR(36) — exactly UUID-sized, no room for a prefix.
+const TEST_INPUT_PREFIX = "TEST_CASCADE_OBS::";
 
 beforeAll(async () => {
   const config = loadConfig();
@@ -34,8 +36,7 @@ beforeAll(async () => {
 afterAll(async () => {
   if (doltAvailable) {
     const pool = getPool();
-    // Tag test rows via request_id prefix so cleanup is precise.
-    await pool.query("DELETE FROM routing_log WHERE request_id LIKE ?", [`${TEST_PREFIX}%`]);
+    await pool.query("DELETE FROM routing_log WHERE input_text LIKE ?", [`${TEST_INPUT_PREFIX}%`]);
   }
   await destroy();
 });
@@ -57,8 +58,8 @@ async function seedRoutingLog(
        VALUES (?, ?, ?, ?, ?, ?, ?, ?, NULL)`,
       [
         uuidv7(),
-        `${TEST_PREFIX}${uuidv7()}`,
-        "test prompt",
+        uuidv7(),
+        `${TEST_INPUT_PREFIX}${r.layer}-${r.tier}`,
         r.tier,
         r.layer,
         r.sim,
@@ -75,7 +76,7 @@ describe("GET /observability/cascade", () => {
 
     // Use a 1-hour window after cleaning out test data so we can assert zeros.
     const pool = getPool();
-    await pool.query("DELETE FROM routing_log WHERE request_id LIKE ?", [`${TEST_PREFIX}%`]);
+    await pool.query("DELETE FROM routing_log WHERE input_text LIKE ?", [`${TEST_INPUT_PREFIX}%`]);
 
     const res = await app.request("/observability/cascade?hours=1");
     expect(res.status).toBe(200);
@@ -100,7 +101,7 @@ describe("GET /observability/cascade", () => {
     if (!doltAvailable) skip();
 
     const pool = getPool();
-    await pool.query("DELETE FROM routing_log WHERE request_id LIKE ?", [`${TEST_PREFIX}%`]);
+    await pool.query("DELETE FROM routing_log WHERE input_text LIKE ?", [`${TEST_INPUT_PREFIX}%`]);
 
     await seedRoutingLog([
       { layer: "deterministic", tier: 1, latency: 5, conf: 1.0, sim: null },

--- a/tests/api/observability-cascade.test.ts
+++ b/tests/api/observability-cascade.test.ts
@@ -82,6 +82,9 @@ describe("GET /observability/cascade", () => {
     expect(res.status).toBe(200);
     const body = (await res.json()) as Record<string, unknown>;
     expect(body).toHaveProperty("window_hours", 1);
+    expect(body).toHaveProperty("snapshot_at");
+    expect(typeof body.snapshot_at).toBe("string");
+    expect(body).toHaveProperty("consistency", "best_effort");
     expect(body).toHaveProperty("total_decisions");
     expect(body).toHaveProperty("by_layer");
     const byLayer = body.by_layer as Record<string, unknown>;
@@ -117,7 +120,12 @@ describe("GET /observability/cascade", () => {
       total_decisions: number;
       by_layer: Record<string, { count: number; share: number }>;
       by_tier: Record<string, { count: number }>;
-      near_misses: Array<{ similarity_score: number; routing_layer: string }>;
+      near_misses: Array<{
+        similarity_score: number;
+        routing_layer: string;
+        input_text_sha256: string;
+        input_text?: string;
+      }>;
     };
 
     expect(body.total_decisions).toBe(5);
@@ -134,6 +142,26 @@ describe("GET /observability/cascade", () => {
     expect(body.near_misses.length).toBe(1);
     expect(body.near_misses[0].similarity_score).toBeCloseTo(0.4);
     expect(body.near_misses[0].routing_layer).toBe("escalation");
+    // PII guard: hash always present, raw text omitted by default.
+    expect(body.near_misses[0].input_text_sha256).toMatch(/^[0-9a-f]{64}$/);
+    expect(body.near_misses[0].input_text).toBeUndefined();
+  });
+
+  it("opts into raw input_text only when include_text=true", async ({ skip }) => {
+    if (!doltAvailable) skip();
+
+    const pool = getPool();
+    await pool.query("DELETE FROM routing_log WHERE input_text LIKE ?", [`${TEST_INPUT_PREFIX}%`]);
+    await seedRoutingLog([{ layer: "escalation", tier: 3, latency: 450, conf: 0.85, sim: 0.4 }]);
+
+    const res = await app.request("/observability/cascade?hours=1&include_text=true");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      near_misses: Array<{ input_text_sha256: string; input_text?: string }>;
+    };
+    expect(body.near_misses.length).toBe(1);
+    expect(body.near_misses[0].input_text_sha256).toMatch(/^[0-9a-f]{64}$/);
+    expect(body.near_misses[0].input_text).toBe(`${TEST_INPUT_PREFIX}escalation-3`);
   });
 
   it("clamps the hours parameter to the valid range", async ({ skip }) => {

--- a/tests/observability/cascade.test.ts
+++ b/tests/observability/cascade.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect } from "vitest";
+import {
+  percentile,
+  percentileBlock,
+  shareByLayer,
+  shareByTier,
+  latencyByLayer,
+} from "../../src/observability/cascade.js";
+
+describe("percentile", () => {
+  it("returns 0 for an empty array", () => {
+    expect(percentile([], 50)).toBe(0);
+  });
+
+  it("returns the only value for a single-element array regardless of p", () => {
+    expect(percentile([42], 50)).toBe(42);
+    expect(percentile([42], 95)).toBe(42);
+    expect(percentile([42], 99)).toBe(42);
+  });
+
+  it("computes nearest-rank percentiles", () => {
+    const v = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+    expect(percentile(v, 50)).toBe(5);
+    expect(percentile(v, 95)).toBe(10);
+    expect(percentile(v, 99)).toBe(10);
+  });
+
+  it("does not mutate the input array", () => {
+    const input = [3, 1, 2];
+    const snapshot = [...input];
+    percentile(input, 50);
+    expect(input).toEqual(snapshot);
+  });
+});
+
+describe("percentileBlock", () => {
+  it("returns zeroed block for empty input", () => {
+    expect(percentileBlock([])).toEqual({ p50: 0, p95: 0, p99: 0, max: 0 });
+  });
+
+  it("computes p50/p95/p99/max with two-decimal rounding", () => {
+    const v = Array.from({ length: 100 }, (_, i) => i + 1); // 1..100
+    const block = percentileBlock(v);
+    expect(block.p50).toBe(50);
+    expect(block.p95).toBe(95);
+    expect(block.p99).toBe(99);
+    expect(block.max).toBe(100);
+  });
+
+  it("rounds float inputs to 2dp", () => {
+    expect(percentileBlock([0.123456])).toEqual({
+      p50: 0.12,
+      p95: 0.12,
+      p99: 0.12,
+      max: 0.12,
+    });
+  });
+});
+
+describe("shareByLayer", () => {
+  it("ensures all four known layers are present even when some have zero counts", () => {
+    const { total, out } = shareByLayer([
+      { layer: "deterministic", count: 80 },
+      { layer: "semantic", count: 20 },
+    ]);
+    expect(total).toBe(100);
+    expect(out.deterministic).toEqual({ count: 80, share: 0.8 });
+    expect(out.semantic).toEqual({ count: 20, share: 0.2 });
+    expect(out.escalation).toEqual({ count: 0, share: 0 });
+    expect(out.fallback).toEqual({ count: 0, share: 0 });
+  });
+
+  it("rounds shares to 4dp and sums close to 1", () => {
+    const { out } = shareByLayer([
+      { layer: "deterministic", count: 1 },
+      { layer: "semantic", count: 1 },
+      { layer: "escalation", count: 1 },
+    ]);
+    // 1/3 = 0.3333 (4dp). Three of them sum to 0.9999 — accept rounding noise.
+    const sum = out.deterministic.share + out.semantic.share + out.escalation.share;
+    expect(sum).toBeGreaterThan(0.999);
+    expect(sum).toBeLessThanOrEqual(1);
+  });
+
+  it("ignores unknown layer names without crashing", () => {
+    // Forward compatibility: if a future migration adds a new layer name,
+    // the snapshot endpoint shouldn't break — it just won't aggregate it.
+    const { total, out } = shareByLayer([
+      { layer: "deterministic", count: 5 },
+      { layer: "unicorn", count: 3 },
+    ]);
+    expect(total).toBe(8); // total still includes the unknown bucket
+    expect(out.deterministic.count).toBe(5);
+    expect(Object.keys(out)).toEqual(["deterministic", "semantic", "escalation", "fallback"]);
+  });
+
+  it("returns zeroed block when no rows are supplied", () => {
+    const { total, out } = shareByLayer([]);
+    expect(total).toBe(0);
+    for (const layer of ["deterministic", "semantic", "escalation", "fallback"] as const) {
+      expect(out[layer]).toEqual({ count: 0, share: 0 });
+    }
+  });
+});
+
+describe("shareByTier", () => {
+  it("computes share per tier and stringifies tier keys", () => {
+    const out = shareByTier([
+      { tier: 1, count: 25 },
+      { tier: 2, count: 25 },
+      { tier: 3, count: 50 },
+    ]);
+    expect(out["1"]).toEqual({ count: 25, share: 0.25 });
+    expect(out["2"]).toEqual({ count: 25, share: 0.25 });
+    expect(out["3"]).toEqual({ count: 50, share: 0.5 });
+  });
+
+  it("returns an empty object when no tiers are present", () => {
+    expect(shareByTier([])).toEqual({});
+  });
+});
+
+describe("latencyByLayer", () => {
+  it("groups samples by layer and computes percentile blocks", () => {
+    const samples = [
+      { layer: "deterministic", latency_ms: 1, confidence: null, similarity_score: null },
+      { layer: "deterministic", latency_ms: 2, confidence: null, similarity_score: null },
+      { layer: "semantic", latency_ms: 100, confidence: 0.8, similarity_score: 0.7 },
+      { layer: "semantic", latency_ms: 200, confidence: 0.85, similarity_score: 0.75 },
+      { layer: "escalation", latency_ms: 500, confidence: 0.9, similarity_score: null },
+    ];
+    const out = latencyByLayer(samples);
+    expect(out.deterministic).toBeDefined();
+    expect(out.semantic).toBeDefined();
+    expect(out.escalation).toBeDefined();
+    expect(out.deterministic!.max).toBe(2);
+    expect(out.semantic!.max).toBe(200);
+    expect(out.escalation!.max).toBe(500);
+  });
+
+  it("omits layers that have no samples", () => {
+    const out = latencyByLayer([
+      { layer: "deterministic", latency_ms: 1, confidence: null, similarity_score: null },
+    ]);
+    expect(out.deterministic).toBeDefined();
+    expect(out.semantic).toBeUndefined();
+    expect(out.escalation).toBeUndefined();
+    expect(out.fallback).toBeUndefined();
+  });
+
+  it("ignores unknown layer names", () => {
+    const out = latencyByLayer([
+      { layer: "future-layer", latency_ms: 999, confidence: null, similarity_score: null },
+      { layer: "deterministic", latency_ms: 1, confidence: null, similarity_score: null },
+    ]);
+    expect(Object.keys(out)).toEqual(["deterministic"]);
+  });
+});


### PR DESCRIPTION
## Summary
The cascade router has captured rich `CascadeTrace` data on every routing decision since v0.4 — but until now it lived per-task with no aggregate view. These endpoints surface that data so operators can see how the routing brain is performing in production traffic and tune `similarity_threshold` / `escalation_threshold` / `confidence_threshold` from data instead of guessing.

Pairs naturally with `npm run load-test` (PR #46): the load test catches routing regressions in synthetic runs, these endpoints catch them in real traffic.

## What's new

`GET /observability/cascade?hours=N` — snapshot:
- `by_layer` hit-rate (deterministic / semantic / escalation / fallback) with all four keys always present even at zero
- `by_tier` distribution
- `latency_ms` overall p50/p95/p99/max + `latency_by_layer_ms` per-layer percentiles
- `confidence` and `similarity_score` percentile distributions
- `near_misses` — top 20 decisions where the semantic layer was consulted but did not resolve, sorted by `similarity_score DESC` (the most informative samples for tuning `similarity_threshold`)

`GET /observability/cascade/timeseries?hours=N&bucket=hour|day` — bucketed `escalation_rate`, `fallback_rate`, total volume, and `avg_latency_ms` over time. SQL bucketing via `FROM_UNIXTIME(FLOOR(...))` keeps bucket keys stable.

## Architecture (matches existing observability stack)
- `src/observability/cascade-queries.ts` — thin SQL functions over `routing_log` (uses indexes from migration 017)
- `src/observability/cascade.ts` — service layer; pure helpers (`percentile`, `shareByLayer`, `shareByTier`, `latencyByLayer`) exported for direct testing
- Endpoints wired into `src/api/routes/observability.ts`

## Tests
- **16 pure-logic tests** (`tests/observability/cascade.test.ts`) — no Dolt needed, covers percentile math, share rounding, layer/tier aggregation, forward compatibility with unknown layer names, latency-by-layer grouping
- **6 endpoint smoke tests** (`tests/api/observability-cascade.test.ts`) — uses skip-when-Dolt-unavailable pattern. Skip-detection is hardened: `doltAvailable` is set after `runMigrations()` succeeds rather than after a bare `SELECT 1`, so a missing `haol` database surfaces as a clean skip instead of a 500 from the route.

## Live verification
Ran end-to-end against real Dolt + 23 cascade decisions from the load test:

```
Layer hit-rate:
  deterministic   21   91.3%  ████████████████████████████████████
  semantic         0    0.0%
  escalation       2    8.7%  ███
  fallback         0    0.0%

Tier distribution:
  T1   6   26.1%  ██████████
  T2   1    4.3%  █
  T3  14   60.9%  ████████████████████████
  T4   2    8.7%  ███
```

Immediately delivered actionable signal: 61% of decisions land at T3, even though the load test's routing assertions flagged 13/23 prompts as expected T1/T2. The router is over-escalating — exactly the kind of insight this endpoint was built to surface and that wasn't visible from per-task traces alone.

## Test plan
- [x] `npm run build` passes
- [x] `npm run format:check` passes
- [x] `npx vitest run tests/observability/cascade.test.ts` — 16/16 pass without Dolt
- [x] `npx vitest run tests/api/observability-cascade.test.ts` — 6/6 pass against live Dolt
- [x] End-to-end: load test → endpoint returns correct counts and shape
- [x] CI passes on the PR

## Follow-ups (separate PRs, not blocking)
Two real bugs / issues surfaced during the live test that are worth their own work:

1. **One-shot count anomaly** on the very first endpoint call after a test run had just deleted rows — `sample_size` and `by_tier sum` were briefly less than `total_decisions`. Did not reproduce in 3 subsequent calls. Likely a Dolt connection-state issue worth investigating.
2. **Router over-escalates to T3**: 61% T3 share with 13 tier mismatches. The deterministic rules likely have over-broad regex patterns capturing T3 prompts that should be T1/T2. Worth a tuning pass (or the routing-tuner is the right tool for this).