### PR TITLE
Make POST /tasks async (202 + worker + poll)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,8 @@ PORT=3000
 # Async task pipeline
 # Number of pipeline jobs the in-process worker runs in parallel.
 WORKER_CONCURRENCY=4
+# Maximum in-memory queue depth before POST /tasks returns 503.
+WORKER_MAX_QUEUE_DEPTH=1000
 # How long a row may sit in QUEUED/RECEIVED/CLASSIFIED/DISPATCHED before
 # the reaper considers it abandoned by a crashed worker. Must be well above
 # the longest tier-4 LLM timeout (120s). Default 600000 (10 min).

--- a/.env.example
+++ b/.env.example
@@ -17,3 +17,13 @@ OPENAI_API_KEY=
 
 # HTTP server
 PORT=3000
+
+# Async task pipeline
+# Number of pipeline jobs the in-process worker runs in parallel.
+WORKER_CONCURRENCY=4
+# How long a row may sit in QUEUED/RECEIVED/CLASSIFIED/DISPATCHED before
+# the reaper considers it abandoned by a crashed worker. Must be well above
+# the longest tier-4 LLM timeout (120s). Default 600000 (10 min).
+WORKER_RECOVERY_AGE_MS=600000
+# Reaper sweep cadence in ms. Default 60000 (1 min).
+WORKER_REAPER_INTERVAL_MS=60000

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,8 @@ The system follows a pipeline pattern orchestrated by `src/router/router.ts`:
 
 Hono HTTP framework. Routes in `src/api/routes/`. Endpoints: `/health`, `/tasks`, `/agents`, `/observability/*`.
 
+`POST /tasks` is **asynchronous**: it validates the input, inserts a `task_log` row in `QUEUED` status, hands the job to the in-process worker (`src/services/task-worker.ts`), and returns `202 Accepted` with `{ task_id, status: "QUEUED", links.self }` plus a `Location` header. Clients poll `GET /tasks/:id` until `done: true`. The worker drains the queue with bounded concurrency (`WORKER_CONCURRENCY`); on crash, the reaper (`src/services/task-reaper.ts`) re-enqueues stranded `QUEUED` rows and marks rows stuck in `RECEIVED/CLASSIFIED/DISPATCHED` past `WORKER_RECOVERY_AGE_MS` as `FAILED` with `worker_error="worker_crashed"`.
+
 ### CLI
 
 Entry point: `src/bin/haol.ts` → `src/cli/index.ts`. Commands: `task`, `status`, `agents`, `history`, `stats`, `audit`.

--- a/src/api/routes/tasks.ts
+++ b/src/api/routes/tasks.ts
@@ -1,13 +1,21 @@
 import { Hono } from "hono";
-import { routeTask } from "../../router/router.js";
-import { findById } from "../../repositories/task-log.js";
+import * as taskLog from "../../repositories/task-log.js";
 import { findByTaskId } from "../../repositories/execution-log.js";
 import { findTraceByTaskId } from "../../cascade-router/reference-store.js";
 import { RouterTaskInput } from "../../types/router.js";
+import { uuidv7, sha256 } from "../../types/task.js";
+import * as worker from "../../services/task-worker.js";
 import { NotFoundError, ValidationError } from "../middleware/error-handler.js";
 
 const tasks = new Hono();
 
+/**
+ * Async intake. We do the bare minimum synchronously — validate, allocate
+ * task_id, persist QUEUED row with the full input — then hand off to the
+ * in-process worker and return 202. The pipeline (classify → select →
+ * execute → commit) runs in the background and the caller polls
+ * GET /tasks/:id for status.
+ */
 tasks.post("/tasks", async (c) => {
   const body = await c.req.json();
   const parsed = RouterTaskInput.safeParse(body);
@@ -15,25 +23,47 @@ tasks.post("/tasks", async (c) => {
     throw new ValidationError(parsed.error.message);
   }
 
-  const result = await routeTask(parsed.data);
-  const statusCode = result.status === "FAILED" ? 500 : 201;
-  return c.json(result, statusCode);
+  const taskId = uuidv7();
+  const promptHash = sha256(parsed.data.prompt);
+
+  await taskLog.createQueued(taskId, promptHash, {
+    prompt: parsed.data.prompt,
+    metadata: parsed.data.metadata as Record<string, unknown> | undefined,
+    constraints: parsed.data.constraints as Record<string, unknown> | undefined,
+    expected_format: parsed.data.expected_format as Record<string, unknown> | undefined,
+  });
+  worker.enqueue(taskId, parsed.data);
+
+  c.header("Location", `/tasks/${taskId}`);
+  c.header("Retry-After", "1");
+  return c.json(
+    {
+      task_id: taskId,
+      status: "QUEUED",
+      links: { self: `/tasks/${taskId}` },
+    },
+    202,
+  );
 });
 
 tasks.get("/tasks/:id", async (c) => {
   const taskId = c.req.param("id");
-  const task = await findById(taskId);
+  const task = await taskLog.findById(taskId);
   if (!task) {
     throw new NotFoundError(`Task not found: ${taskId}`);
   }
 
-  // Include execution log if completed/failed
-  let executions = undefined;
-  if (task.status === "COMPLETED" || task.status === "FAILED") {
-    executions = await findByTaskId(taskId);
-  }
+  const done = task.status === "COMPLETED" || task.status === "FAILED";
+  const executions = done ? await findByTaskId(taskId) : undefined;
 
-  return c.json({ ...task, executions }, 200);
+  return c.json(
+    {
+      ...task,
+      done,
+      executions,
+    },
+    200,
+  );
 });
 
 tasks.get("/tasks/:id/trace", async (c) => {

--- a/src/api/routes/tasks.ts
+++ b/src/api/routes/tasks.ts
@@ -23,6 +23,14 @@ tasks.post("/tasks", async (c) => {
     throw new ValidationError(parsed.error.message);
   }
 
+  // Backpressure: refuse intake before writing a QUEUED row when the
+  // worker queue is saturated. Returning 429 lets the caller back off
+  // instead of silently piling up rows the reaper has to clean later.
+  if (!worker.canAccept()) {
+    c.header("Retry-After", "5");
+    return c.json({ error: "task queue full, retry shortly" }, 503);
+  }
+
   const taskId = uuidv7();
   const promptHash = sha256(parsed.data.prompt);
 
@@ -32,7 +40,13 @@ tasks.post("/tasks", async (c) => {
     constraints: parsed.data.constraints as Record<string, unknown> | undefined,
     expected_format: parsed.data.expected_format as Record<string, unknown> | undefined,
   });
-  worker.enqueue(taskId, parsed.data);
+  const enqueueResult = worker.enqueue(taskId, parsed.data);
+  if (enqueueResult !== "ok") {
+    // Lost the race against another concurrent intake or shutdown — leave
+    // the row QUEUED for the reaper rather than orphaning the caller.
+    c.header("Retry-After", "5");
+    return c.json({ error: "task queue unavailable, retry shortly" }, 503);
+  }
 
   c.header("Location", `/tasks/${taskId}`);
   c.header("Retry-After", "1");

--- a/src/cascade-router/cascade-router.ts
+++ b/src/cascade-router/cascade-router.ts
@@ -69,7 +69,7 @@ export class CascadeRouter {
     this.state = { rules, utterances, config, tiers };
   }
 
-  async classify(input: TaskInput): Promise<TaskClassification> {
+  async classify(input: TaskInput, preAllocatedTaskId?: string): Promise<TaskClassification> {
     if (!this.state) {
       await this.load();
     }
@@ -236,7 +236,7 @@ export class CascadeRouter {
     }
 
     const latencyMs = performance.now() - start;
-    const taskId = uuidv7();
+    const taskId = preAllocatedTaskId ?? uuidv7();
 
     const cascadeTrace: CascadeTrace = {
       layers: trace,

--- a/src/cascade-router/classify.ts
+++ b/src/cascade-router/classify.ts
@@ -50,9 +50,12 @@ async function getInstance(): Promise<CascadeRouter> {
   return instancePromise;
 }
 
-export async function classifyCascade(input: TaskInput): Promise<TaskClassification> {
+export async function classifyCascade(
+  input: TaskInput,
+  preAllocatedTaskId?: string,
+): Promise<TaskClassification> {
   const router = await getInstance();
-  return router.classify(input);
+  return router.classify(input, preAllocatedTaskId);
 }
 
 /** Reset the singleton (for testing) */

--- a/src/classifier/classifier.ts
+++ b/src/classifier/classifier.ts
@@ -4,7 +4,7 @@ import { skippedAttempt } from "../cascade-router/types.js";
 import { matchRules } from "./rules.js";
 import { computeTier, costCeilingForTier } from "./scoring.js";
 
-export function classify(input: TaskInput): TaskClassification {
+export function classify(input: TaskInput, preAllocatedTaskId?: string): TaskClassification {
   const start = performance.now();
 
   // 1. Validate input with Zod
@@ -34,8 +34,9 @@ export function classify(input: TaskInput): TaskClassification {
   // 5. Compute cost ceiling
   const cost_ceiling_usd = costCeilingForTier(tier);
 
-  // 6. Generate task ID and prompt hash
-  const task_id = uuidv7();
+  // 6. Generate task ID and prompt hash (caller may pre-allocate the id when
+  // the task was already inserted into task_log by the async intake path).
+  const task_id = preAllocatedTaskId ?? uuidv7();
   const prompt_hash = sha256(parsed.prompt);
 
   const elapsed = performance.now() - start;

--- a/src/cli/commands/task.ts
+++ b/src/cli/commands/task.ts
@@ -29,10 +29,33 @@ async function pollTask(baseUrl: string, taskId: string, timeoutMs: number): Pro
   let lastBody: TaskBody = {};
   let backoffMs = 250;
   while (Date.now() < deadline) {
-    const res = await fetch(`${baseUrl}/tasks/${taskId}`);
-    lastBody = (await res.json()) as TaskBody;
-    if (lastBody.done === true) return lastBody;
-    if (lastBody.status === "COMPLETED" || lastBody.status === "FAILED") return lastBody;
+    let res: Response;
+    try {
+      res = await fetch(`${baseUrl}/tasks/${taskId}`);
+    } catch (err) {
+      // Network error — surface immediately rather than spinning to deadline.
+      return { task_id: taskId, error: `poll request failed: ${(err as Error).message}` };
+    }
+    // Permanent failures: 4xx (incl. 404 if the row was reaped) and any
+    // non-{503,429} 5xx — break out instead of looping silently.
+    if (!res.ok && res.status !== 503 && res.status !== 429) {
+      let body: TaskBody = {};
+      try {
+        body = (await res.json()) as TaskBody;
+      } catch {
+        // non-JSON body — fall through with synthesized error
+      }
+      return {
+        ...body,
+        task_id: body.task_id ?? taskId,
+        error: body.error ?? `poll failed with HTTP ${res.status}`,
+      };
+    }
+    if (res.ok) {
+      lastBody = (await res.json()) as TaskBody;
+      if (lastBody.done === true) return lastBody;
+      if (lastBody.status === "COMPLETED" || lastBody.status === "FAILED") return lastBody;
+    }
     await new Promise((r) => setTimeout(r, backoffMs));
     backoffMs = Math.min(backoffMs * 1.5, 2_000);
   }

--- a/src/cli/commands/task.ts
+++ b/src/cli/commands/task.ts
@@ -24,11 +24,7 @@ interface TaskBody {
   [key: string]: unknown;
 }
 
-async function pollTask(
-  baseUrl: string,
-  taskId: string,
-  timeoutMs: number,
-): Promise<TaskBody> {
+async function pollTask(baseUrl: string, taskId: string, timeoutMs: number): Promise<TaskBody> {
   const deadline = Date.now() + timeoutMs;
   let lastBody: TaskBody = {};
   let backoffMs = 250;

--- a/src/cli/commands/task.ts
+++ b/src/cli/commands/task.ts
@@ -6,6 +6,41 @@ export interface TaskCommandOptions {
   capabilities?: string[];
   format: OutputFormat;
   baseUrl: string;
+  /**
+   * Max time to poll for completion after submission. Defaults to 180s
+   * which is above the longest tier-4 LLM timeout. Set to 0 to skip
+   * polling and return immediately after the 202.
+   */
+  waitTimeoutMs?: number;
+}
+
+interface TaskBody {
+  task_id?: string;
+  status?: string;
+  done?: boolean;
+  response_content?: string | null;
+  error?: string | null;
+  links?: { self?: string };
+  [key: string]: unknown;
+}
+
+async function pollTask(
+  baseUrl: string,
+  taskId: string,
+  timeoutMs: number,
+): Promise<TaskBody> {
+  const deadline = Date.now() + timeoutMs;
+  let lastBody: TaskBody = {};
+  let backoffMs = 250;
+  while (Date.now() < deadline) {
+    const res = await fetch(`${baseUrl}/tasks/${taskId}`);
+    lastBody = (await res.json()) as TaskBody;
+    if (lastBody.done === true) return lastBody;
+    if (lastBody.status === "COMPLETED" || lastBody.status === "FAILED") return lastBody;
+    await new Promise((r) => setTimeout(r, backoffMs));
+    backoffMs = Math.min(backoffMs * 1.5, 2_000);
+  }
+  return { ...lastBody, error: lastBody.error ?? "timeout waiting for task to finish" };
 }
 
 export async function taskCommand(opts: TaskCommandOptions): Promise<string> {
@@ -23,9 +58,18 @@ export async function taskCommand(opts: TaskCommandOptions): Promise<string> {
     body: JSON.stringify(body),
   });
 
-  const data = await res.json();
+  let data = (await res.json()) as TaskBody;
 
-  if (!res.ok && opts.format !== "json") {
+  // Async pipeline: POST returns 202+QUEUED. Poll until terminal so the CLI
+  // experience stays synchronous-feeling. If the caller asked for waitTimeoutMs=0
+  // they can opt out and just see the QUEUED handle.
+  const waitMs = opts.waitTimeoutMs ?? 180_000;
+  if (res.ok && res.status === 202 && data.task_id && waitMs > 0) {
+    data = await pollTask(opts.baseUrl, data.task_id, waitMs);
+  }
+
+  const httpFailed = !res.ok && res.status !== 202;
+  if (httpFailed && opts.format !== "json") {
     return `Error (${res.status}): ${data.error ?? "Unknown error"}`;
   }
 
@@ -41,10 +85,18 @@ export async function taskCommand(opts: TaskCommandOptions): Promise<string> {
   const lines = [
     `Task ID:    ${data.task_id}`,
     `Status:     ${data.status}`,
-    `Tier:       T${data.complexity_tier ?? "?"}`,
-    `Agent:      ${data.selected_agent_id ?? "none"}`,
-    `Cost:       ${data.cost_usd != null ? "$" + data.cost_usd.toFixed(4) : "n/a"}`,
-    `Latency:    ${data.latency_ms != null ? data.latency_ms + "ms" : "n/a"}`,
+    `Tier:       T${(data as { complexity_tier?: number }).complexity_tier ?? "?"}`,
+    `Agent:      ${(data as { selected_agent_id?: string }).selected_agent_id ?? "none"}`,
+    `Cost:       ${
+      (data as { cost_usd?: number }).cost_usd != null
+        ? "$" + (data as { cost_usd: number }).cost_usd.toFixed(4)
+        : "n/a"
+    }`,
+    `Latency:    ${
+      (data as { latency_ms?: number }).latency_ms != null
+        ? (data as { latency_ms: number }).latency_ms + "ms"
+        : "n/a"
+    }`,
   ];
 
   if (data.response_content) {

--- a/src/db/migrations/019_async_task_pipeline.sql
+++ b/src/db/migrations/019_async_task_pipeline.sql
@@ -1,0 +1,32 @@
+-- Async task pipeline: POST /tasks now returns 202 immediately and a
+-- background worker drives the classify/select/execute pipeline. To support
+-- this, task_log needs to store the original input (so the reaper can
+-- re-enqueue stranded QUEUED rows after a process crash) and worker
+-- bookkeeping columns. A new QUEUED status sits before RECEIVED, and a
+-- composite index makes the reaper/worker poll cheap.
+--
+-- QUEUED is appended (not prepended) to the ENUM to preserve the integer
+-- ordinals of existing values. Order in the ENUM declaration is storage
+-- order, not workflow order.
+
+ALTER TABLE task_log
+  MODIFY status ENUM('RECEIVED','CLASSIFIED','DISPATCHED','COMPLETED','FAILED','QUEUED') NOT NULL;
+
+ALTER TABLE task_log ADD COLUMN prompt LONGTEXT DEFAULT NULL;
+
+ALTER TABLE task_log ADD COLUMN input_metadata JSON DEFAULT NULL;
+
+ALTER TABLE task_log ADD COLUMN input_constraints JSON DEFAULT NULL;
+
+ALTER TABLE task_log ADD COLUMN worker_started_at TIMESTAMP NULL DEFAULT NULL;
+
+ALTER TABLE task_log ADD COLUMN worker_finished_at TIMESTAMP NULL DEFAULT NULL;
+
+ALTER TABLE task_log ADD COLUMN worker_error TEXT DEFAULT NULL;
+
+-- The winning agent's response. Today this lives only in the in-memory
+-- return value of routeTask() — for the async pipeline, GET /tasks/:id
+-- needs a persistent place to read it from.
+ALTER TABLE task_log ADD COLUMN response_content LONGTEXT DEFAULT NULL;
+
+CREATE INDEX idx_task_log_status_created ON task_log (status, created_at);

--- a/src/db/migrations/020_fix_signal_value_nullable.sql
+++ b/src/db/migrations/020_fix_signal_value_nullable.sql
@@ -1,0 +1,13 @@
+-- Migration 010 declared task_outcome.signal_value as TINYINT DEFAULT NULL,
+-- but Dolt interpreted that as NOT NULL DEFAULT NULL (DESCRIBE shows
+-- Null=NO). The application has always treated this column as nullable —
+-- TaskOutcomeRecord.signal_value is number|null, repository INSERTs pass
+-- through nulls, and queries filter signal_value IS NOT NULL. The schema
+-- was the only thing disagreeing.
+--
+-- Two test cases need NULLs to round-trip: the evaluation_pending /
+-- evaluation_failed outcome records inserted by outcome-collector when an
+-- LLM eval is in flight or has failed, and the seed data for
+-- outcomeSignalRates which verifies pending rows are excluded.
+
+ALTER TABLE task_outcome MODIFY signal_value TINYINT NULL DEFAULT NULL;

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,8 @@ import { loadConfig } from "./config.js";
 import { createPool, healthCheck } from "./db/connection.js";
 import { createApp } from "./api/app.js";
 import { validateApiKeyConfig } from "./api/middleware/api-key-auth.js";
+import * as worker from "./services/task-worker.js";
+import { startReaper, stopReaper, runReaperOnce } from "./services/task-reaper.js";
 
 async function main() {
   // Fail fast if production auth is misconfigured — before binding the server.
@@ -19,12 +21,29 @@ async function main() {
     process.exit(1);
   }
 
+  worker.start();
+  // One-shot recovery sweep for tasks stranded by a previous crash, then
+  // start the periodic reaper. Both run before we begin accepting traffic so
+  // a crash-loop can't pile up untouched stale rows.
+  await runReaperOnce();
+  startReaper();
+
   const app = createApp();
   const port = parseInt(process.env.PORT ?? "3000", 10);
 
-  serve({ fetch: app.fetch, port }, (info) => {
+  const server = serve({ fetch: app.fetch, port }, (info) => {
     console.log("HAOL API server listening on http://localhost:%d", info.port);
   });
+
+  const shutdown = async (signal: string) => {
+    console.log("[server] received %s, draining…", signal);
+    stopReaper();
+    server.close();
+    await worker.stop();
+    process.exit(0);
+  };
+  process.on("SIGTERM", () => void shutdown("SIGTERM"));
+  process.on("SIGINT", () => void shutdown("SIGINT"));
 }
 
 main();

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,7 +38,14 @@ async function main() {
   const shutdown = async (signal: string) => {
     console.log("[server] received %s, draining…", signal);
     stopReaper();
-    server.close();
+    // Await server.close so any in-flight POST handlers between the
+    // createQueued INSERT and worker.enqueue() can finish before the
+    // worker stops accepting new enqueues. Without this, a late enqueue
+    // would be rejected and the row stranded as QUEUED until the next
+    // reaper sweep on restart.
+    await new Promise<void>((resolve, reject) => {
+      server.close((err) => (err ? reject(err) : resolve()));
+    });
     await worker.stop();
     process.exit(0);
   };

--- a/src/repositories/task-log.ts
+++ b/src/repositories/task-log.ts
@@ -201,10 +201,9 @@ export async function recordWorkerError(taskId: string, message: string): Promis
 
 export async function recordWorkerFinished(taskId: string): Promise<void> {
   const pool = getPool();
-  await pool.query(
-    `UPDATE task_log SET worker_finished_at = CURRENT_TIMESTAMP WHERE task_id = ?`,
-    [taskId],
-  );
+  await pool.query(`UPDATE task_log SET worker_finished_at = CURRENT_TIMESTAMP WHERE task_id = ?`, [
+    taskId,
+  ]);
 }
 
 /**

--- a/src/repositories/task-log.ts
+++ b/src/repositories/task-log.ts
@@ -199,22 +199,44 @@ export async function recordWorkerError(taskId: string, message: string): Promis
   );
 }
 
-export async function recordWorkerFinished(taskId: string): Promise<void> {
+/**
+ * Atomic terminal-state writes for the async pipeline. Combining
+ * status/response_content/finished-stamp into a single UPDATE prevents a
+ * polling client from observing `done: true` with `response_content` still
+ * null between two separate writes.
+ */
+export async function markCompleted(taskId: string, responseContent: string | null): Promise<void> {
   const pool = getPool();
-  await pool.query(`UPDATE task_log SET worker_finished_at = CURRENT_TIMESTAMP WHERE task_id = ?`, [
-    taskId,
-  ]);
+  await pool.query(
+    `UPDATE task_log
+       SET status = 'COMPLETED',
+           response_content = ?,
+           worker_finished_at = CURRENT_TIMESTAMP
+     WHERE task_id = ?`,
+    [responseContent, taskId],
+  );
+}
+
+export async function markFailed(taskId: string): Promise<void> {
+  const pool = getPool();
+  await pool.query(
+    `UPDATE task_log
+       SET status = 'FAILED',
+           worker_finished_at = CURRENT_TIMESTAMP
+     WHERE task_id = ?`,
+    [taskId],
+  );
 }
 
 /**
- * Reaper query: find rows that have been sitting in non-terminal states
- * longer than maxAgeSeconds. Used at startup and periodically to recover
- * from worker crashes.
+ * Reaper query: find rows that have been sitting in non-terminal in-flight
+ * states longer than maxAgeSeconds. QUEUED is excluded — it's handled
+ * separately by findQueued() since it's safe to retry.
  */
 export async function findStale(maxAgeSeconds: number): Promise<TaskLogRecord[]> {
   const rows = await query<TaskLogRow[]>(
     `SELECT * FROM task_log
-       WHERE status IN ('QUEUED','RECEIVED','CLASSIFIED','DISPATCHED')
+       WHERE status IN ('RECEIVED','CLASSIFIED','DISPATCHED')
          AND created_at < (NOW() - INTERVAL ? SECOND)
        ORDER BY created_at ASC`,
     [maxAgeSeconds],
@@ -267,29 +289,16 @@ export async function updateSelection(
   );
 }
 
+/**
+ * Generic status writer. Does NOT stamp worker_finished_at — terminal
+ * transitions in the async pipeline must use markCompleted/markFailed so
+ * status, response, and finish-stamp land in a single UPDATE. This keeps
+ * worker_finished_at meaningful: a row with worker_started_at IS NULL but
+ * worker_finished_at IS NOT NULL would be confusing in observability dashboards.
+ */
 export async function updateStatus(taskId: string, status: TaskStatus): Promise<void> {
   const pool = getPool();
-  // Stamp worker_finished_at when reaching a terminal state so async pollers
-  // see status and finish-time mutate atomically.
-  if (status === "COMPLETED" || status === "FAILED") {
-    await pool.query(
-      `UPDATE task_log SET status = ?, worker_finished_at = CURRENT_TIMESTAMP WHERE task_id = ?`,
-      [status, taskId],
-    );
-  } else {
-    await pool.query(`UPDATE task_log SET status = ? WHERE task_id = ?`, [status, taskId]);
-  }
-}
-
-export async function updateResponseContent(
-  taskId: string,
-  responseContent: string | null,
-): Promise<void> {
-  const pool = getPool();
-  await pool.query(`UPDATE task_log SET response_content = ? WHERE task_id = ?`, [
-    responseContent,
-    taskId,
-  ]);
+  await pool.query(`UPDATE task_log SET status = ? WHERE task_id = ?`, [status, taskId]);
 }
 
 export async function findById(taskId: string): Promise<TaskLogRecord | null> {

--- a/src/repositories/task-log.ts
+++ b/src/repositories/task-log.ts
@@ -217,31 +217,40 @@ export async function markCompleted(taskId: string, responseContent: string | nu
   );
 }
 
-export async function markFailed(taskId: string): Promise<void> {
+export async function markFailed(taskId: string, errorMessage?: string | null): Promise<void> {
   const pool = getPool();
   await pool.query(
     `UPDATE task_log
        SET status = 'FAILED',
+           worker_error = COALESCE(?, worker_error),
            worker_finished_at = CURRENT_TIMESTAMP
      WHERE task_id = ?`,
-    [taskId],
+    [errorMessage ? errorMessage.slice(0, 65535) : null, taskId],
   );
+}
+
+interface StaleTaskRow extends RowDataPacket {
+  task_id: string;
 }
 
 /**
  * Reaper query: find rows that have been sitting in non-terminal in-flight
  * states longer than maxAgeSeconds. QUEUED is excluded — it's handled
  * separately by findQueued() since it's safe to retry.
+ *
+ * Returns only task_ids — the reaper does not need prompt/metadata/etc.
+ * for these rows (it just marks them FAILED + deletes the session branch),
+ * and SELECT * would pull the LONGTEXT prompt for every stale row.
  */
-export async function findStale(maxAgeSeconds: number): Promise<TaskLogRecord[]> {
-  const rows = await query<TaskLogRow[]>(
-    `SELECT * FROM task_log
+export async function findStale(maxAgeSeconds: number): Promise<string[]> {
+  const rows = await query<StaleTaskRow[]>(
+    `SELECT task_id FROM task_log
        WHERE status IN ('RECEIVED','CLASSIFIED','DISPATCHED')
          AND created_at < (NOW() - INTERVAL ? SECOND)
        ORDER BY created_at ASC`,
     [maxAgeSeconds],
   );
-  return rows.map(parseRow);
+  return rows.map((r) => r.task_id);
 }
 
 /**

--- a/src/repositories/task-log.ts
+++ b/src/repositories/task-log.ts
@@ -8,6 +8,9 @@ interface TaskLogRow extends RowDataPacket {
   created_at: string;
   status: string;
   prompt_hash: string | null;
+  prompt: string | null;
+  input_metadata: string | Record<string, unknown> | null;
+  input_constraints: string | Record<string, unknown> | null;
   complexity_tier: number | null;
   required_capabilities: string | string[] | null;
   cost_ceiling_usd: string | number | null;
@@ -16,6 +19,10 @@ interface TaskLogRow extends RowDataPacket {
   routing_confidence: number | null;
   routing_layer: string | null;
   expected_format: string | Record<string, unknown> | null;
+  worker_started_at: string | null;
+  worker_finished_at: string | null;
+  worker_error: string | null;
+  response_content: string | null;
 }
 
 export interface TaskLogRecord {
@@ -23,6 +30,9 @@ export interface TaskLogRecord {
   created_at: string;
   status: TaskStatus;
   prompt_hash: string | null;
+  prompt: string | null;
+  input_metadata: Record<string, unknown> | null;
+  input_constraints: Record<string, unknown> | null;
   complexity_tier: number | null;
   required_capabilities: string[] | null;
   cost_ceiling_usd: number | null;
@@ -31,6 +41,10 @@ export interface TaskLogRecord {
   routing_confidence: number | null;
   routing_layer: string | null;
   expected_format: Record<string, unknown> | null;
+  worker_started_at: string | null;
+  worker_finished_at: string | null;
+  worker_error: string | null;
+  response_content: string | null;
 }
 
 function parseRow(row: TaskLogRow): TaskLogRecord {
@@ -73,11 +87,26 @@ function parseRow(row: TaskLogRow): TaskLogRecord {
     }
   }
 
+  const parseJsonColumn = (
+    val: string | Record<string, unknown> | null,
+  ): Record<string, unknown> | null => {
+    if (val == null) return null;
+    if (typeof val !== "string") return val;
+    try {
+      return JSON.parse(val);
+    } catch {
+      return null;
+    }
+  };
+
   return {
     task_id: row.task_id,
     created_at: row.created_at,
     status: row.status as TaskStatus,
     prompt_hash: row.prompt_hash,
+    prompt: row.prompt,
+    input_metadata: parseJsonColumn(row.input_metadata),
+    input_constraints: parseJsonColumn(row.input_constraints),
     complexity_tier: row.complexity_tier,
     required_capabilities: capabilities,
     cost_ceiling_usd:
@@ -91,6 +120,10 @@ function parseRow(row: TaskLogRow): TaskLogRecord {
     routing_confidence: row.routing_confidence,
     routing_layer: row.routing_layer,
     expected_format: expectedFormat,
+    worker_started_at: row.worker_started_at,
+    worker_finished_at: row.worker_finished_at,
+    worker_error: row.worker_error,
+    response_content: row.response_content,
   };
 }
 
@@ -100,6 +133,105 @@ export async function create(taskId: string, promptHash: string): Promise<void> 
     `INSERT INTO task_log (task_id, status, prompt_hash) VALUES (?, 'RECEIVED', ?)`,
     [taskId, promptHash],
   );
+}
+
+export interface QueuedTaskInput {
+  prompt: string;
+  metadata?: Record<string, unknown>;
+  constraints?: Record<string, unknown>;
+  expected_format?: Record<string, unknown>;
+}
+
+/**
+ * Async-pipeline intake: insert a row in QUEUED status with the full input
+ * stashed so a worker (or the reaper, after a crash) can run the pipeline
+ * later. Distinct from create() so the legacy synchronous CLI path is
+ * untouched.
+ */
+export async function createQueued(
+  taskId: string,
+  promptHash: string,
+  input: QueuedTaskInput,
+): Promise<void> {
+  const pool = getPool();
+  await pool.query(
+    `INSERT INTO task_log
+       (task_id, status, prompt_hash, prompt, input_metadata, input_constraints, expected_format)
+     VALUES (?, 'QUEUED', ?, ?, ?, ?, ?)`,
+    [
+      taskId,
+      promptHash,
+      input.prompt,
+      input.metadata ? JSON.stringify(input.metadata) : null,
+      input.constraints ? JSON.stringify(input.constraints) : null,
+      input.expected_format ? JSON.stringify(input.expected_format) : null,
+    ],
+  );
+}
+
+/**
+ * Worker pickup: transition QUEUED → RECEIVED and stamp worker_started_at.
+ * Conditional on QUEUED so a duplicate enqueue (e.g. reaper racing a live
+ * worker) cannot kick off a second execution. Returns true if this caller
+ * acquired the row.
+ */
+export async function claimQueued(taskId: string): Promise<boolean> {
+  const pool = getPool();
+  const [result] = await pool.query(
+    `UPDATE task_log
+       SET status = 'RECEIVED',
+           worker_started_at = CURRENT_TIMESTAMP
+     WHERE task_id = ? AND status = 'QUEUED'`,
+    [taskId],
+  );
+  return (result as { affectedRows: number }).affectedRows === 1;
+}
+
+export async function recordWorkerError(taskId: string, message: string): Promise<void> {
+  const pool = getPool();
+  await pool.query(
+    `UPDATE task_log
+       SET status = 'FAILED',
+           worker_error = ?,
+           worker_finished_at = CURRENT_TIMESTAMP
+     WHERE task_id = ?`,
+    [message.slice(0, 65535), taskId],
+  );
+}
+
+export async function recordWorkerFinished(taskId: string): Promise<void> {
+  const pool = getPool();
+  await pool.query(
+    `UPDATE task_log SET worker_finished_at = CURRENT_TIMESTAMP WHERE task_id = ?`,
+    [taskId],
+  );
+}
+
+/**
+ * Reaper query: find rows that have been sitting in non-terminal states
+ * longer than maxAgeSeconds. Used at startup and periodically to recover
+ * from worker crashes.
+ */
+export async function findStale(maxAgeSeconds: number): Promise<TaskLogRecord[]> {
+  const rows = await query<TaskLogRow[]>(
+    `SELECT * FROM task_log
+       WHERE status IN ('QUEUED','RECEIVED','CLASSIFIED','DISPATCHED')
+         AND created_at < (NOW() - INTERVAL ? SECOND)
+       ORDER BY created_at ASC`,
+    [maxAgeSeconds],
+  );
+  return rows.map(parseRow);
+}
+
+/**
+ * Returns all currently-QUEUED rows. Used at startup to re-enqueue tasks
+ * that arrived while the worker was down.
+ */
+export async function findQueued(): Promise<TaskLogRecord[]> {
+  const rows = await query<TaskLogRow[]>(
+    `SELECT * FROM task_log WHERE status = 'QUEUED' ORDER BY created_at ASC`,
+  );
+  return rows.map(parseRow);
 }
 
 export async function updateClassification(
@@ -138,7 +270,27 @@ export async function updateSelection(
 
 export async function updateStatus(taskId: string, status: TaskStatus): Promise<void> {
   const pool = getPool();
-  await pool.query(`UPDATE task_log SET status = ? WHERE task_id = ?`, [status, taskId]);
+  // Stamp worker_finished_at when reaching a terminal state so async pollers
+  // see status and finish-time mutate atomically.
+  if (status === "COMPLETED" || status === "FAILED") {
+    await pool.query(
+      `UPDATE task_log SET status = ?, worker_finished_at = CURRENT_TIMESTAMP WHERE task_id = ?`,
+      [status, taskId],
+    );
+  } else {
+    await pool.query(`UPDATE task_log SET status = ? WHERE task_id = ?`, [status, taskId]);
+  }
+}
+
+export async function updateResponseContent(
+  taskId: string,
+  responseContent: string | null,
+): Promise<void> {
+  const pool = getPool();
+  await pool.query(`UPDATE task_log SET response_content = ? WHERE task_id = ?`, [
+    responseContent,
+    taskId,
+  ]);
 }
 
 export async function findById(taskId: string): Promise<TaskLogRecord | null> {

--- a/src/router/router.ts
+++ b/src/router/router.ts
@@ -183,13 +183,13 @@ export async function routeTask(
       }
     }
 
-    // 7. Update final status (and persist response so async pollers can read it)
+    // 7. Atomic terminal-state write — async pollers must never see
+    // status=COMPLETED with response_content=null between two writes.
     if (execResult.outcome === "SUCCESS") {
-      await taskLog.updateResponseContent(taskId, execResult.response_content);
-      await taskLog.updateStatus(taskId, "COMPLETED");
+      await taskLog.markCompleted(taskId, execResult.response_content);
       status = "COMPLETED";
     } else {
-      await taskLog.updateStatus(taskId, "FAILED");
+      await taskLog.markFailed(taskId);
       status = "FAILED";
     }
 
@@ -249,7 +249,7 @@ export async function routeTask(
     // On any error, mark as failed and still commit
     if (taskId) {
       try {
-        await taskLog.updateStatus(taskId, "FAILED");
+        await taskLog.markFailed(taskId);
       } catch {
         // best-effort status update
       }

--- a/src/router/router.ts
+++ b/src/router/router.ts
@@ -189,7 +189,10 @@ export async function routeTask(
       await taskLog.markCompleted(taskId, execResult.response_content);
       status = "COMPLETED";
     } else {
-      await taskLog.markFailed(taskId);
+      // Surface the underlying execution error_detail to worker_error so a
+      // poller hitting GET /tasks/:id can see the failure cause without
+      // having to dig into the executions array.
+      await taskLog.markFailed(taskId, execResult.error_detail);
       status = "FAILED";
     }
 
@@ -246,10 +249,12 @@ export async function routeTask(
         : undefined,
     };
   } catch (err) {
-    // On any error, mark as failed and still commit
+    // On any unhandled error (classify failure, no agents, DB outage),
+    // surface the message to worker_error so callers polling GET /tasks/:id
+    // can distinguish this from a worker-level crash.
     if (taskId) {
       try {
-        await taskLog.markFailed(taskId);
+        await taskLog.markFailed(taskId, (err as Error).message);
       } catch {
         // best-effort status update
       }

--- a/src/router/router.ts
+++ b/src/router/router.ts
@@ -35,10 +35,24 @@ async function routerCommit(message: string): Promise<void> {
   await commitSafely(message, "haol-router <haol@system>", true);
 }
 
-export async function routeTask(input: RouterTaskInput): Promise<TaskResult> {
-  const parsed = RouterTaskInputSchema.parse(input);
+export interface RouteTaskOptions {
+  /**
+   * Pre-allocated task_id from the async intake path. When provided, the
+   * caller has already inserted a row in task_log (typically QUEUED) and
+   * routeTask will reuse this id throughout — including in classifier
+   * decision logs — and skip the INSERT.
+   */
+  taskId?: string;
+}
 
-  let taskId: string | null = null;
+export async function routeTask(
+  input: RouterTaskInput,
+  options: RouteTaskOptions = {},
+): Promise<TaskResult> {
+  const parsed = RouterTaskInputSchema.parse(input);
+  const preAllocated = options.taskId;
+
+  let taskId: string | null = preAllocated ?? null;
   let status: TaskResult["status"] = "RECEIVED";
   let cascadeTrace: CascadeTrace | undefined;
   let selectionResult: SelectionResult | undefined;
@@ -47,21 +61,30 @@ export async function routeTask(input: RouterTaskInput): Promise<TaskResult> {
     // 1. Classify — try cascade router, fall back to old classifier
     let classification: TaskClassification;
     try {
-      classification = await classifyCascade({
-        prompt: parsed.prompt,
-        metadata: parsed.metadata,
-      });
+      classification = await classifyCascade(
+        {
+          prompt: parsed.prompt,
+          metadata: parsed.metadata,
+        },
+        preAllocated,
+      );
     } catch {
-      classification = classify({
-        prompt: parsed.prompt,
-        metadata: parsed.metadata,
-      });
+      classification = classify(
+        {
+          prompt: parsed.prompt,
+          metadata: parsed.metadata,
+        },
+        preAllocated,
+      );
     }
     taskId = classification.task_id;
     cascadeTrace = classification.cascade_trace;
 
-    // 2. Intake — write to task_log
-    await taskLog.create(taskId, classification.prompt_hash);
+    // 2. Intake — write to task_log unless caller pre-inserted the row
+    // (async path inserts in QUEUED status before the worker picks it up).
+    if (!preAllocated) {
+      await taskLog.create(taskId, classification.prompt_hash);
+    }
     status = "RECEIVED";
 
     // Store routing confidence on task_log (after create so the row exists)
@@ -160,8 +183,9 @@ export async function routeTask(input: RouterTaskInput): Promise<TaskResult> {
       }
     }
 
-    // 7. Update final status
+    // 7. Update final status (and persist response so async pollers can read it)
     if (execResult.outcome === "SUCCESS") {
+      await taskLog.updateResponseContent(taskId, execResult.response_content);
       await taskLog.updateStatus(taskId, "COMPLETED");
       status = "COMPLETED";
     } else {

--- a/src/services/routing-tuner.ts
+++ b/src/services/routing-tuner.ts
@@ -161,7 +161,7 @@ export async function findSuccessfulEscalations(
      WHERE rl.routing_layer = 'escalation'
        AND rl.confidence >= ?
        AND rl.created_at >= DATE_SUB(NOW(), INTERVAL ? HOUR)
-       AND t.status = 'completed'
+       AND t.status = 'COMPLETED'
        AND EXISTS (
          SELECT 1 FROM task_outcome o
          WHERE o.task_id = t.task_id
@@ -196,7 +196,7 @@ export async function findSuccessfulFallbacks(hours: number): Promise<FallbackSu
      JOIN task_log t ON t.task_id = rl.request_id
      WHERE rl.routing_layer = 'fallback'
        AND rl.created_at >= DATE_SUB(NOW(), INTERVAL ? HOUR)
-       AND t.status = 'completed'
+       AND t.status = 'COMPLETED'
        AND EXISTS (
          SELECT 1 FROM task_outcome o
          WHERE o.task_id = t.task_id

--- a/src/services/task-reaper.ts
+++ b/src/services/task-reaper.ts
@@ -1,0 +1,145 @@
+import * as taskLog from "../repositories/task-log.js";
+import * as worker from "./task-worker.js";
+import { doltDeleteBranch } from "../db/dolt.js";
+import type { RouterTaskInput } from "../types/router.js";
+
+/**
+ * Crash-recovery reaper for the async task pipeline.
+ *
+ *  - QUEUED rows are re-enqueued — they never started, so retrying is safe.
+ *  - RECEIVED/CLASSIFIED/DISPATCHED rows older than the recovery threshold
+ *    are marked FAILED. We deliberately do NOT retry these: an LLM call may
+ *    have partially completed and been billed, and double-charging on a
+ *    transient crash is worse than surfacing a clean failure to the caller.
+ *  - On reap-to-FAILED, best-effort delete the per-task Dolt session branch
+ *    so it doesn't accumulate on disk.
+ *
+ * The recovery threshold is intentionally well above the longest tier-4
+ * timeout (120s) — a healthy worker may legitimately hold a row in
+ * DISPATCHED for two minutes. Default 10 min; tune via WORKER_RECOVERY_AGE_MS.
+ */
+
+const STUCK_REASON = "worker_crashed";
+
+let timer: NodeJS.Timeout | null = null;
+
+function recoveryAgeSeconds(): number {
+  const raw = process.env.WORKER_RECOVERY_AGE_MS;
+  if (!raw) return 600; // 10 minutes
+  const ms = parseInt(raw, 10);
+  if (!Number.isFinite(ms) || ms < 1000) return 600;
+  return Math.ceil(ms / 1000);
+}
+
+function reaperIntervalMs(): number {
+  const raw = process.env.WORKER_REAPER_INTERVAL_MS;
+  if (!raw) return 60_000;
+  const ms = parseInt(raw, 10);
+  return Number.isFinite(ms) && ms >= 1000 ? ms : 60_000;
+}
+
+function reconstructInput(record: taskLog.TaskLogRecord): RouterTaskInput | null {
+  if (!record.prompt) return null;
+  // DB columns return null for absent JSON; the Zod schema requires
+  // object | undefined, so coerce.
+  const input: RouterTaskInput = { prompt: record.prompt };
+  if (record.input_metadata) {
+    input.metadata = record.input_metadata as RouterTaskInput["metadata"];
+  }
+  if (record.input_constraints) {
+    input.constraints = record.input_constraints as RouterTaskInput["constraints"];
+  }
+  if (record.expected_format) {
+    input.expected_format = record.expected_format as RouterTaskInput["expected_format"];
+  }
+  return input;
+}
+
+async function deleteSessionBranchSafely(taskId: string): Promise<void> {
+  try {
+    await doltDeleteBranch(`session/${taskId}`);
+  } catch {
+    // Branch may not exist (task crashed before memory step) or may already
+    // have been merged. Either way, nothing to recover.
+  }
+}
+
+export async function runReaperOnce(): Promise<{
+  reEnqueued: number;
+  failed: number;
+}> {
+  const ageSec = recoveryAgeSeconds();
+  let reEnqueued = 0;
+  let failed = 0;
+
+  // 1. Re-enqueue any QUEUED row regardless of age — the in-memory queue is
+  // empty at startup, so anything that survived a restart needs a kick. At
+  // steady state during periodic sweeps, claimQueued() will harmlessly
+  // refuse duplicates.
+  let queued: taskLog.TaskLogRecord[] = [];
+  try {
+    queued = await taskLog.findQueued();
+  } catch (err) {
+    console.warn("[reaper] findQueued failed: %s", (err as Error).message);
+  }
+  for (const row of queued) {
+    const input = reconstructInput(row);
+    if (!input) {
+      // Row predates the async pipeline (no stashed prompt); fail it.
+      try {
+        await taskLog.recordWorkerError(row.task_id, "queued_without_prompt");
+        failed++;
+      } catch {
+        // best-effort
+      }
+      continue;
+    }
+    worker.enqueue(row.task_id, input);
+    reEnqueued++;
+  }
+
+  // 2. Mark stale in-flight rows FAILED. Filter to states that imply a
+  // worker had picked the row up (skip QUEUED — handled above).
+  let stale: taskLog.TaskLogRecord[] = [];
+  try {
+    stale = await taskLog.findStale(ageSec);
+  } catch (err) {
+    console.warn("[reaper] findStale failed: %s", (err as Error).message);
+  }
+  for (const row of stale) {
+    if (row.status === "QUEUED") continue;
+    try {
+      await taskLog.recordWorkerError(row.task_id, STUCK_REASON);
+      await deleteSessionBranchSafely(row.task_id);
+      failed++;
+    } catch (err) {
+      console.warn(
+        "[reaper] failed to mark %s FAILED: %s",
+        row.task_id,
+        (err as Error).message,
+      );
+    }
+  }
+
+  if (reEnqueued > 0 || failed > 0) {
+    console.log("[reaper] re-enqueued=%d failed=%d", reEnqueued, failed);
+  }
+  return { reEnqueued, failed };
+}
+
+export function startReaper(): void {
+  if (timer) return;
+  timer = setInterval(() => {
+    runReaperOnce().catch((err) => {
+      console.warn("[reaper] sweep failed: %s", (err as Error).message);
+    });
+  }, reaperIntervalMs());
+  timer.unref();
+}
+
+export function stopReaper(): void {
+  if (timer) {
+    clearInterval(timer);
+    timer = null;
+  }
+}

--- a/src/services/task-reaper.ts
+++ b/src/services/task-reaper.ts
@@ -113,11 +113,7 @@ export async function runReaperOnce(): Promise<{
       await deleteSessionBranchSafely(row.task_id);
       failed++;
     } catch (err) {
-      console.warn(
-        "[reaper] failed to mark %s FAILED: %s",
-        row.task_id,
-        (err as Error).message,
-      );
+      console.warn("[reaper] failed to mark %s FAILED: %s", row.task_id, (err as Error).message);
     }
   }
 

--- a/src/services/task-reaper.ts
+++ b/src/services/task-reaper.ts
@@ -23,11 +23,16 @@ const STUCK_REASON = "worker_crashed";
 
 let timer: NodeJS.Timeout | null = null;
 
+// Floor the recovery threshold at 5 min so a misconfigured value can't
+// reap healthy in-flight T3/T4 tasks (tier-4 timeout is 120s; we need
+// well above that plus reaper-interval slop to be safe).
+const RECOVERY_AGE_FLOOR_MS = 300_000;
+
 function recoveryAgeSeconds(): number {
   const raw = process.env.WORKER_RECOVERY_AGE_MS;
   if (!raw) return 600; // 10 minutes
   const ms = parseInt(raw, 10);
-  if (!Number.isFinite(ms) || ms < 1000) return 600;
+  if (!Number.isFinite(ms) || ms < RECOVERY_AGE_FLOOR_MS) return 600;
   return Math.ceil(ms / 1000);
 }
 

--- a/src/services/task-reaper.ts
+++ b/src/services/task-reaper.ts
@@ -103,22 +103,22 @@ export async function runReaperOnce(): Promise<{
     reEnqueued++;
   }
 
-  // 2. Mark stale in-flight rows FAILED. Filter to states that imply a
-  // worker had picked the row up (skip QUEUED — handled above).
-  let stale: taskLog.TaskLogRecord[] = [];
+  // 2. Mark stale in-flight rows FAILED. findStale returns just the
+  // task_ids — no need to pull full rows (incl. LONGTEXT prompt) since
+  // the reaper only needs to UPDATE and delete the session branch.
+  let staleIds: string[] = [];
   try {
-    stale = await taskLog.findStale(ageSec);
+    staleIds = await taskLog.findStale(ageSec);
   } catch (err) {
     console.warn("[reaper] findStale failed: %s", (err as Error).message);
   }
-  for (const row of stale) {
-    if (row.status === "QUEUED") continue;
+  for (const taskId of staleIds) {
     try {
-      await taskLog.recordWorkerError(row.task_id, STUCK_REASON);
-      await deleteSessionBranchSafely(row.task_id);
+      await taskLog.recordWorkerError(taskId, STUCK_REASON);
+      await deleteSessionBranchSafely(taskId);
       failed++;
     } catch (err) {
-      console.warn("[reaper] failed to mark %s FAILED: %s", row.task_id, (err as Error).message);
+      console.warn("[reaper] failed to mark %s FAILED: %s", taskId, (err as Error).message);
     }
   }
 

--- a/src/services/task-worker.ts
+++ b/src/services/task-worker.ts
@@ -1,0 +1,153 @@
+import { routeTask } from "../router/router.js";
+import * as taskLog from "../repositories/task-log.js";
+import type { RouterTaskInput } from "../types/router.js";
+
+/**
+ * In-process background worker for the async POST /tasks pipeline.
+ *
+ * Design:
+ *  - The HTTP handler inserts a row in task_log with status QUEUED, then calls
+ *    enqueue(). The worker drains an in-memory queue and runs routeTask() on
+ *    each job up to WORKER_CONCURRENCY in parallel.
+ *  - claimQueued() conditionally transitions QUEUED → RECEIVED; if a duplicate
+ *    enqueue arrives (e.g. the reaper races a live worker), the second claim
+ *    fails harmlessly and the job is dropped.
+ *  - On crash, anything still in QUEUED/RECEIVED/CLASSIFIED/DISPATCHED is
+ *    handled by the reaper at next startup (see startReaper). The worker
+ *    itself only owns the in-memory queue.
+ */
+
+interface Job {
+  taskId: string;
+  input: RouterTaskInput;
+}
+
+const queue: Job[] = [];
+let inflight = 0;
+let started = false;
+let stopping = false;
+let drainResolver: (() => void) | null = null;
+
+function workerConcurrency(): number {
+  const raw = process.env.WORKER_CONCURRENCY;
+  if (!raw) return 4;
+  const n = parseInt(raw, 10);
+  return Number.isFinite(n) && n > 0 ? n : 4;
+}
+
+export function enqueue(taskId: string, input: RouterTaskInput): void {
+  queue.push({ taskId, input });
+  // Kick the loop on next tick so callers (HTTP handler) can return first.
+  setImmediate(pump);
+}
+
+function pump(): void {
+  if (stopping) {
+    maybeResolveDrain();
+    return;
+  }
+  const max = workerConcurrency();
+  while (inflight < max && queue.length > 0) {
+    const job = queue.shift()!;
+    inflight++;
+    runJob(job).finally(() => {
+      inflight--;
+      if (queue.length > 0) {
+        setImmediate(pump);
+      } else {
+        maybeResolveDrain();
+      }
+    });
+  }
+}
+
+async function runJob(job: Job): Promise<void> {
+  // Claim the row — if another worker (or the reaper) already moved it past
+  // QUEUED, drop this duplicate enqueue silently.
+  let claimed = false;
+  try {
+    claimed = await taskLog.claimQueued(job.taskId);
+  } catch (err) {
+    console.warn(
+      "[task-worker] claimQueued failed for %s: %s",
+      job.taskId,
+      (err as Error).message,
+    );
+    return;
+  }
+  if (!claimed) return;
+
+  try {
+    // routeTask sets status to COMPLETED/FAILED and stamps worker_finished_at
+    // atomically (see taskLog.updateStatus for the terminal-state case).
+    await routeTask(job.input, { taskId: job.taskId });
+  } catch (err) {
+    // routeTask handles its own failures and writes FAILED to task_log, but
+    // any unhandled throw (DB outage, etc.) lands here. Best-effort mark the
+    // row FAILED so callers polling GET /tasks/:id see a terminal state.
+    const message = err instanceof Error ? err.message : String(err);
+    console.error("[task-worker] uncaught error for %s: %s", job.taskId, message);
+    try {
+      await taskLog.recordWorkerError(job.taskId, message);
+    } catch (writeErr) {
+      console.error(
+        "[task-worker] failed to record worker_error for %s: %s",
+        job.taskId,
+        (writeErr as Error).message,
+      );
+    }
+  }
+}
+
+function maybeResolveDrain(): void {
+  if (stopping && inflight === 0 && queue.length === 0 && drainResolver) {
+    drainResolver();
+    drainResolver = null;
+  }
+}
+
+export function start(): void {
+  if (started) return;
+  started = true;
+  stopping = false;
+}
+
+/**
+ * Drain any in-flight work and refuse new enqueues. Called on SIGTERM by the
+ * server entry point. The grace period bounds how long we'll wait for
+ * in-flight LLM calls to finish before the process exits anyway.
+ */
+export async function stop(graceMs = 30_000): Promise<void> {
+  if (!started) return;
+  stopping = true;
+  if (inflight === 0 && queue.length === 0) return;
+
+  await new Promise<void>((resolve) => {
+    drainResolver = resolve;
+    setTimeout(() => {
+      if (drainResolver) {
+        console.warn(
+          "[task-worker] grace period exceeded with %d in-flight jobs",
+          inflight,
+        );
+        const r = drainResolver;
+        drainResolver = null;
+        r();
+      }
+    }, graceMs).unref();
+  });
+}
+
+/** Test/observability hook. */
+export function inspect(): { queued: number; inflight: number } {
+  return { queued: queue.length, inflight };
+}
+
+/** Test reset — clears in-memory state without touching the DB. */
+export function _resetForTests(): void {
+  queue.length = 0;
+  inflight = 0;
+  started = false;
+  stopping = false;
+  drainResolver = null;
+}

--- a/src/services/task-worker.ts
+++ b/src/services/task-worker.ts
@@ -42,6 +42,12 @@ function workerConcurrency(): number {
 }
 
 export function enqueue(taskId: string, input: RouterTaskInput): void {
+  // Reject during shutdown: pump() bails when stopping=true, so a late
+  // enqueue would sit in queue forever and prevent maybeResolveDrain() from
+  // firing — stop() would then hang until its grace-period timeout. Server
+  // shutdown order normally prevents this, but a concurrent reaper sweep
+  // can still call enqueue() after stop() begins.
+  if (stopping) return;
   if (tracked.has(taskId)) return; // duplicate — already queued or running
   tracked.add(taskId);
   queue.push({ taskId, input });

--- a/src/services/task-worker.ts
+++ b/src/services/task-worker.ts
@@ -68,11 +68,7 @@ async function runJob(job: Job): Promise<void> {
   try {
     claimed = await taskLog.claimQueued(job.taskId);
   } catch (err) {
-    console.warn(
-      "[task-worker] claimQueued failed for %s: %s",
-      job.taskId,
-      (err as Error).message,
-    );
+    console.warn("[task-worker] claimQueued failed for %s: %s", job.taskId, (err as Error).message);
     return;
   }
   if (!claimed) return;
@@ -126,10 +122,7 @@ export async function stop(graceMs = 30_000): Promise<void> {
     drainResolver = resolve;
     setTimeout(() => {
       if (drainResolver) {
-        console.warn(
-          "[task-worker] grace period exceeded with %d in-flight jobs",
-          inflight,
-        );
+        console.warn("[task-worker] grace period exceeded with %d in-flight jobs", inflight);
         const r = drainResolver;
         drainResolver = null;
         r();

--- a/src/services/task-worker.ts
+++ b/src/services/task-worker.ts
@@ -23,6 +23,12 @@ interface Job {
 }
 
 const queue: Job[] = [];
+// Tracks task IDs that are queued or in-flight in *this* process. The DB
+// claimQueued gate is the cross-process source of truth (it protects against
+// the reaper racing a live worker), but in-process duplicates need to be
+// caught here — we cannot rely on Dolt's isolation to serialize two near-
+// simultaneous UPDATE...WHERE status='QUEUED' statements on the same row.
+const tracked = new Set<string>();
 let inflight = 0;
 let started = false;
 let stopping = false;
@@ -36,6 +42,8 @@ function workerConcurrency(): number {
 }
 
 export function enqueue(taskId: string, input: RouterTaskInput): void {
+  if (tracked.has(taskId)) return; // duplicate — already queued or running
+  tracked.add(taskId);
   queue.push({ taskId, input });
   // Kick the loop on next tick so callers (HTTP handler) can return first.
   setImmediate(pump);
@@ -52,6 +60,7 @@ function pump(): void {
     inflight++;
     runJob(job).finally(() => {
       inflight--;
+      tracked.delete(job.taskId);
       if (queue.length > 0) {
         setImmediate(pump);
       } else {
@@ -139,6 +148,7 @@ export function inspect(): { queued: number; inflight: number } {
 /** Test reset — clears in-memory state without touching the DB. */
 export function _resetForTests(): void {
   queue.length = 0;
+  tracked.clear();
   inflight = 0;
   started = false;
   stopping = false;

--- a/src/services/task-worker.ts
+++ b/src/services/task-worker.ts
@@ -41,18 +41,34 @@ function workerConcurrency(): number {
   return Number.isFinite(n) && n > 0 ? n : 4;
 }
 
-export function enqueue(taskId: string, input: RouterTaskInput): void {
+function maxQueueDepth(): number {
+  const raw = process.env.WORKER_MAX_QUEUE_DEPTH;
+  if (!raw) return 1000;
+  const n = parseInt(raw, 10);
+  return Number.isFinite(n) && n > 0 ? n : 1000;
+}
+
+export type EnqueueResult = "ok" | "stopping" | "duplicate" | "queue_full";
+
+export function enqueue(taskId: string, input: RouterTaskInput): EnqueueResult {
   // Reject during shutdown: pump() bails when stopping=true, so a late
   // enqueue would sit in queue forever and prevent maybeResolveDrain() from
   // firing — stop() would then hang until its grace-period timeout. Server
   // shutdown order normally prevents this, but a concurrent reaper sweep
   // can still call enqueue() after stop() begins.
-  if (stopping) return;
-  if (tracked.has(taskId)) return; // duplicate — already queued or running
+  if (stopping) return "stopping";
+  if (tracked.has(taskId)) return "duplicate"; // already queued or running
+  // Cap the in-memory queue so a sustained intake burst can't OOM the
+  // process. The HTTP handler converts queue_full into 429 so callers get
+  // an actionable signal instead of accumulating silently. Long-term the
+  // Dolt-backed poll queue will replace this; the cap is the defense in
+  // the meantime.
+  if (queue.length >= maxQueueDepth()) return "queue_full";
   tracked.add(taskId);
   queue.push({ taskId, input });
   // Kick the loop on next tick so callers (HTTP handler) can return first.
   setImmediate(pump);
+  return "ok";
 }
 
 function pump(): void {
@@ -89,8 +105,9 @@ async function runJob(job: Job): Promise<void> {
   if (!claimed) return;
 
   try {
-    // routeTask sets status to COMPLETED/FAILED and stamps worker_finished_at
-    // atomically (see taskLog.updateStatus for the terminal-state case).
+    // routeTask writes the terminal status via markCompleted/markFailed,
+    // which atomically stamp status, response_content (on success), and
+    // worker_finished_at in a single UPDATE.
     await routeTask(job.input, { taskId: job.taskId });
   } catch (err) {
     // routeTask handles its own failures and writes FAILED to task_log, but
@@ -147,8 +164,17 @@ export async function stop(graceMs = 30_000): Promise<void> {
 }
 
 /** Test/observability hook. */
-export function inspect(): { queued: number; inflight: number } {
-  return { queued: queue.length, inflight };
+export function inspect(): { queued: number; inflight: number; capacity: number } {
+  return { queued: queue.length, inflight, capacity: maxQueueDepth() };
+}
+
+/**
+ * Pre-flight check used by the HTTP handler to return 429 before
+ * inserting a QUEUED row. Avoids creating orphan QUEUED rows that the
+ * reaper would have to clean up later.
+ */
+export function canAccept(): boolean {
+  return !stopping && queue.length < maxQueueDepth();
 }
 
 /** Test reset — clears in-memory state without touching the DB. */

--- a/src/types/router.ts
+++ b/src/types/router.ts
@@ -3,7 +3,14 @@ import { FormatSpec } from "./outcome.js";
 import { CascadeTraceSchema } from "../cascade-router/types.js";
 import { ScoredCandidate } from "./selection.js";
 
-export const TaskStatus = z.enum(["RECEIVED", "CLASSIFIED", "DISPATCHED", "COMPLETED", "FAILED"]);
+export const TaskStatus = z.enum([
+  "QUEUED",
+  "RECEIVED",
+  "CLASSIFIED",
+  "DISPATCHED",
+  "COMPLETED",
+  "FAILED",
+]);
 export type TaskStatus = z.infer<typeof TaskStatus>;
 
 export const RouterTaskInput = z.object({

--- a/tests/api/tasks.test.ts
+++ b/tests/api/tasks.test.ts
@@ -10,6 +10,10 @@ import type { Hono } from "hono";
 let doltAvailable = false;
 let app: Hono;
 const originalFetch = globalThis.fetch;
+// Explicit prefix on every prompt this test suite POSTs so afterAll cleanup
+// can match exactly without the ambiguity of broad LIKE patterns like
+// '%review%' which would collide with prompts seeded by other test files.
+const TEST_PROMPT_PREFIX = "[tasks-api.test] ";
 
 function mockFetchSuccess(content: string = "Mock response") {
   globalThis.fetch = vi.fn().mockImplementation(async (url: string) => {
@@ -128,10 +132,9 @@ afterAll(async () => {
     await pool.query("DELETE FROM routing_log WHERE input_text LIKE '%trace test%'");
     await pool.query("DELETE FROM execution_log WHERE agent_id LIKE 'api-task-%'");
     await pool.query("DELETE FROM task_log WHERE selected_agent_id LIKE 'api-task-%'");
-    // Best-effort cleanup of QUEUED rows we may have left without a selected_agent_id
-    await pool.query("DELETE FROM task_log WHERE prompt LIKE '%trace test%'");
-    await pool.query("DELETE FROM task_log WHERE prompt LIKE '%review%'");
-    await pool.query("DELETE FROM task_log WHERE prompt LIKE '%testing%'");
+    // Cleanup any QUEUED/orphan rows from this suite that never reached
+    // selected_agent_id assignment.
+    await pool.query("DELETE FROM task_log WHERE prompt LIKE ?", [`${TEST_PROMPT_PREFIX}%`]);
     // Re-enable seed agents
     await pool.query(
       `UPDATE agent_registry SET status = 'active'
@@ -150,7 +153,7 @@ describe("POST /tasks", () => {
     const res = await app.request("/tasks", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ prompt: "Summarize this text about testing" }),
+      body: JSON.stringify({ prompt: `${TEST_PROMPT_PREFIX}summarize text about testing` }),
     });
 
     expect(res.status).toBe(202);
@@ -189,7 +192,7 @@ describe("GET /tasks/:id", () => {
     const createRes = await app.request("/tasks", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ prompt: "Classify this review" }),
+      body: JSON.stringify({ prompt: `${TEST_PROMPT_PREFIX}classify this review` }),
     });
     const created = await createRes.json();
 
@@ -218,7 +221,9 @@ describe("GET /tasks/:id/trace", () => {
     const createRes = await app.request("/tasks", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ prompt: "Summarize this article for trace test" }),
+      body: JSON.stringify({
+        prompt: `${TEST_PROMPT_PREFIX}summarize this article for trace test`,
+      }),
     });
     const created = await createRes.json();
 

--- a/tests/api/tasks.test.ts
+++ b/tests/api/tasks.test.ts
@@ -4,6 +4,7 @@ import { uuidv7 } from "../../src/types/task.js";
 import { loadConfig } from "../../src/config.js";
 import { runMigrations } from "../../src/db/migrate.js";
 import { createApp } from "../../src/api/app.js";
+import * as worker from "../../src/services/task-worker.js";
 import type { Hono } from "hono";
 
 let doltAvailable = false;
@@ -44,6 +45,29 @@ function mockFetchSuccess(content: string = "Mock response") {
       }),
     };
   }) as unknown as typeof fetch;
+}
+
+async function pollUntilDone(
+  taskId: string,
+  timeoutMs = 10_000,
+): Promise<{ status: number; body: Record<string, unknown> }> {
+  const deadline = Date.now() + timeoutMs;
+  let lastBody: Record<string, unknown> = {};
+  let lastStatus = 0;
+  while (Date.now() < deadline) {
+    const res = await app.request(`/tasks/${taskId}`);
+    lastStatus = res.status;
+    lastBody = (await res.json()) as Record<string, unknown>;
+    if (lastBody.done === true) {
+      return { status: lastStatus, body: lastBody };
+    }
+    await new Promise((r) => setTimeout(r, 25));
+  }
+  throw new Error(
+    `Task ${taskId} did not finish within ${timeoutMs}ms — last status=${
+      lastBody.status as string
+    }`,
+  );
 }
 
 beforeAll(async () => {
@@ -89,6 +113,7 @@ beforeAll(async () => {
     console.warn("Dolt not available — skipping tasks API tests");
   }
   app = createApp();
+  worker.start();
 });
 
 afterEach(() => {
@@ -96,11 +121,17 @@ afterEach(() => {
 });
 
 afterAll(async () => {
+  await worker.stop(2_000);
+  worker._resetForTests();
   if (doltAvailable) {
     const pool = getPool();
     await pool.query("DELETE FROM routing_log WHERE input_text LIKE '%trace test%'");
     await pool.query("DELETE FROM execution_log WHERE agent_id LIKE 'api-task-%'");
     await pool.query("DELETE FROM task_log WHERE selected_agent_id LIKE 'api-task-%'");
+    // Best-effort cleanup of QUEUED rows we may have left without a selected_agent_id
+    await pool.query("DELETE FROM task_log WHERE prompt LIKE '%trace test%'");
+    await pool.query("DELETE FROM task_log WHERE prompt LIKE '%review%'");
+    await pool.query("DELETE FROM task_log WHERE prompt LIKE '%testing%'");
     // Re-enable seed agents
     await pool.query(
       `UPDATE agent_registry SET status = 'active'
@@ -112,7 +143,7 @@ afterAll(async () => {
 });
 
 describe("POST /tasks", () => {
-  it("submits a task with valid prompt → 201", async ({ skip }) => {
+  it("returns 202 + task_id immediately (does not block on LLM)", async ({ skip }) => {
     if (!doltAvailable) skip();
     mockFetchSuccess("Summary result");
 
@@ -122,11 +153,19 @@ describe("POST /tasks", () => {
       body: JSON.stringify({ prompt: "Summarize this text about testing" }),
     });
 
-    expect(res.status).toBe(201);
+    expect(res.status).toBe(202);
+    expect(res.headers.get("Location")).toMatch(/^\/tasks\/.+/);
+    expect(res.headers.get("Retry-After")).toBe("1");
+
     const body = await res.json();
     expect(body.task_id).toBeTruthy();
-    expect(body.status).toBe("COMPLETED");
-    expect(body.response_content).toBe("Summary result");
+    expect(body.status).toBe("QUEUED");
+    expect(body.links?.self).toBe(`/tasks/${body.task_id}`);
+
+    // Worker drains the queue and the task reaches COMPLETED.
+    const polled = await pollUntilDone(body.task_id);
+    expect(polled.body.status).toBe("COMPLETED");
+    expect(polled.body.response_content).toBe("Summary result");
   });
 
   it("rejects empty prompt → 400", async ({ skip }) => {
@@ -143,11 +182,10 @@ describe("POST /tasks", () => {
 });
 
 describe("GET /tasks/:id", () => {
-  it("returns task with current status", async ({ skip }) => {
+  it("returns task with current status (eventually COMPLETED)", async ({ skip }) => {
     if (!doltAvailable) skip();
     mockFetchSuccess("Done.");
 
-    // First create a task
     const createRes = await app.request("/tasks", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -155,14 +193,13 @@ describe("GET /tasks/:id", () => {
     });
     const created = await createRes.json();
 
-    // Then fetch it
-    const res = await app.request(`/tasks/${created.task_id}`);
-    expect(res.status).toBe(200);
-
-    const body = await res.json();
-    expect(body.task_id).toBe(created.task_id);
-    expect(body.status).toBe("COMPLETED");
-    expect(body.executions).toBeTruthy();
+    const polled = await pollUntilDone(created.task_id);
+    expect(polled.status).toBe(200);
+    expect(polled.body.task_id).toBe(created.task_id);
+    expect(polled.body.status).toBe("COMPLETED");
+    expect(polled.body.done).toBe(true);
+    expect(polled.body.executions).toBeTruthy();
+    expect(polled.body.response_content).toBe("Done.");
   });
 
   it("returns 404 for non-existent task", async ({ skip }) => {
@@ -184,6 +221,9 @@ describe("GET /tasks/:id/trace", () => {
       body: JSON.stringify({ prompt: "Summarize this article for trace test" }),
     });
     const created = await createRes.json();
+
+    // Wait for the worker to finish so the task_log row is in a stable state
+    await pollUntilDone(created.task_id);
 
     // Seed a routing_log entry with cascade_trace metadata for this task
     const cascadeTrace = {

--- a/tests/cli/task.test.ts
+++ b/tests/cli/task.test.ts
@@ -8,18 +8,47 @@ afterEach(() => {
   globalThis.fetch = originalFetch;
 });
 
-function mockTaskResponse(data: Record<string, unknown>, status = 201) {
+/**
+ * Mocks the async POST 202 → GET poll flow. POST returns 202 with a
+ * task_id; subsequent GETs return the completion payload (done=true).
+ */
+function mockAsyncFlow(completion: Record<string, unknown>, taskId = "abc-123") {
+  globalThis.fetch = vi
+    .fn()
+    .mockImplementation(async (url: string | URL, init?: RequestInit) => {
+      const u = typeof url === "string" ? url : url.toString();
+      const method = (init?.method ?? "GET").toUpperCase();
+      if (method === "POST" && u.endsWith("/tasks")) {
+        return {
+          ok: true,
+          status: 202,
+          json: async () => ({
+            task_id: taskId,
+            status: "QUEUED",
+            links: { self: `/tasks/${taskId}` },
+          }),
+        };
+      }
+      // GET poll
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ task_id: taskId, done: true, ...completion }),
+      };
+    }) as unknown as typeof fetch;
+}
+
+function mockPostError(status: number, body: Record<string, unknown>) {
   globalThis.fetch = vi.fn().mockResolvedValue({
     ok: status >= 200 && status < 300,
     status,
-    json: async () => data,
+    json: async () => body,
   }) as unknown as typeof fetch;
 }
 
 describe("task command", () => {
-  it("prints task_id and response in table format", async () => {
-    mockTaskResponse({
-      task_id: "abc-123",
+  it("polls after 202 and prints task_id and response in table format", async () => {
+    mockAsyncFlow({
       status: "COMPLETED",
       complexity_tier: 1,
       selected_agent_id: "haiku",
@@ -43,8 +72,7 @@ describe("task command", () => {
   });
 
   it("outputs valid JSON in json format", async () => {
-    const data = {
-      task_id: "abc-123",
+    mockAsyncFlow({
       status: "COMPLETED",
       complexity_tier: 1,
       selected_agent_id: "haiku",
@@ -52,8 +80,7 @@ describe("task command", () => {
       cost_usd: 0.001,
       latency_ms: 200,
       error: null,
-    };
-    mockTaskResponse(data);
+    });
 
     const output = await taskCommand({
       prompt: "Hello",
@@ -67,8 +94,7 @@ describe("task command", () => {
   });
 
   it("outputs minimal format", async () => {
-    mockTaskResponse({
-      task_id: "abc-123",
+    mockAsyncFlow({
       status: "COMPLETED",
       response_content: "Result",
       error: null,
@@ -85,8 +111,8 @@ describe("task command", () => {
     expect(output).toContain("Result");
   });
 
-  it("shows error on failure", async () => {
-    mockTaskResponse({ error: "No agent available" }, 500);
+  it("shows error on POST failure (no polling)", async () => {
+    mockPostError(500, { error: "No agent available" });
 
     const output = await taskCommand({
       prompt: "Hello",
@@ -98,8 +124,23 @@ describe("task command", () => {
     expect(output).toContain("No agent available");
   });
 
+  it("waitTimeoutMs=0 skips the poll and returns the QUEUED handle", async () => {
+    mockAsyncFlow({ status: "COMPLETED", response_content: "should not appear" });
+
+    const output = await taskCommand({
+      prompt: "fire and forget",
+      format: "minimal",
+      baseUrl: "http://localhost:3000",
+      waitTimeoutMs: 0,
+    });
+
+    expect(output).toContain("abc-123");
+    expect(output).toContain("QUEUED");
+    expect(output).not.toContain("should not appear");
+  });
+
   it("sends tier and capabilities metadata", async () => {
-    mockTaskResponse({ task_id: "x", status: "COMPLETED" });
+    mockAsyncFlow({ status: "COMPLETED" });
 
     await taskCommand({
       prompt: "Test",
@@ -109,8 +150,10 @@ describe("task command", () => {
       baseUrl: "http://localhost:3000",
     });
 
-    const call = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
-    const body = JSON.parse(call[1].body);
+    const postCall = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls.find(
+      (c) => (c[1]?.method ?? "GET") === "POST",
+    )!;
+    const body = JSON.parse((postCall[1] as { body: string }).body);
     expect(body.metadata.tier).toBe(3);
     expect(body.metadata.capabilities).toEqual(["reasoning", "code_generation"]);
   });
@@ -118,16 +161,18 @@ describe("task command", () => {
 
 describe("run() — task command via CLI entry", () => {
   it("haol task 'hello' invokes task command", async () => {
-    mockTaskResponse({
-      task_id: "run-test",
-      status: "COMPLETED",
-      complexity_tier: 1,
-      selected_agent_id: "haiku",
-      response_content: "Hello!",
-      cost_usd: 0.001,
-      latency_ms: 100,
-      error: null,
-    });
+    mockAsyncFlow(
+      {
+        status: "COMPLETED",
+        complexity_tier: 1,
+        selected_agent_id: "haiku",
+        response_content: "Hello!",
+        cost_usd: 0.001,
+        latency_ms: 100,
+        error: null,
+      },
+      "run-test",
+    );
 
     const output = await run(["node", "haol", "task", "hello"]);
     expect(output).toContain("run-test");
@@ -135,12 +180,14 @@ describe("run() — task command via CLI entry", () => {
   });
 
   it("haol task with --tier and --cap flags", async () => {
-    mockTaskResponse({ task_id: "t", status: "COMPLETED" });
+    mockAsyncFlow({ status: "COMPLETED" }, "t");
 
     await run(["node", "haol", "task", "test", "--tier", "3", "--cap", "reasoning"]);
 
-    const call = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
-    const body = JSON.parse(call[1].body);
+    const postCall = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls.find(
+      (c) => (c[1]?.method ?? "GET") === "POST",
+    )!;
+    const body = JSON.parse((postCall[1] as { body: string }).body);
     expect(body.metadata.tier).toBe(3);
     expect(body.metadata.capabilities).toEqual(["reasoning"]);
   });

--- a/tests/cli/task.test.ts
+++ b/tests/cli/task.test.ts
@@ -13,29 +13,27 @@ afterEach(() => {
  * task_id; subsequent GETs return the completion payload (done=true).
  */
 function mockAsyncFlow(completion: Record<string, unknown>, taskId = "abc-123") {
-  globalThis.fetch = vi
-    .fn()
-    .mockImplementation(async (url: string | URL, init?: RequestInit) => {
-      const u = typeof url === "string" ? url : url.toString();
-      const method = (init?.method ?? "GET").toUpperCase();
-      if (method === "POST" && u.endsWith("/tasks")) {
-        return {
-          ok: true,
-          status: 202,
-          json: async () => ({
-            task_id: taskId,
-            status: "QUEUED",
-            links: { self: `/tasks/${taskId}` },
-          }),
-        };
-      }
-      // GET poll
+  globalThis.fetch = vi.fn().mockImplementation(async (url: string | URL, init?: RequestInit) => {
+    const u = typeof url === "string" ? url : url.toString();
+    const method = (init?.method ?? "GET").toUpperCase();
+    if (method === "POST" && u.endsWith("/tasks")) {
       return {
         ok: true,
-        status: 200,
-        json: async () => ({ task_id: taskId, done: true, ...completion }),
+        status: 202,
+        json: async () => ({
+          task_id: taskId,
+          status: "QUEUED",
+          links: { self: `/tasks/${taskId}` },
+        }),
       };
-    }) as unknown as typeof fetch;
+    }
+    // GET poll
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({ task_id: taskId, done: true, ...completion }),
+    };
+  }) as unknown as typeof fetch;
 }
 
 function mockPostError(status: number, body: Record<string, unknown>) {

--- a/tests/db/migrations.test.ts
+++ b/tests/db/migrations.test.ts
@@ -39,16 +39,16 @@ describe("migrations", () => {
   it("applies all migration files without error", async ({ skip }) => {
     if (!doltAvailable) skip();
     const applied = await runMigrations();
-    expect(applied.length).toBe(18);
+    expect(applied.length).toBe(20);
     expect(applied[0]).toBe("001_create_agent_registry.sql");
-    expect(applied[17]).toBe("018_tighten_routing_rules.sql");
+    expect(applied[19]).toBe("020_fix_signal_value_nullable.sql");
   });
 
   it("is idempotent — running twice produces no errors", async ({ skip }) => {
     if (!doltAvailable) skip();
     // Second run should not throw
     const applied = await runMigrations();
-    expect(applied.length).toBe(18);
+    expect(applied.length).toBe(20);
   });
 
   it("creates expected tables", async ({ skip }) => {
@@ -87,11 +87,34 @@ describe("migrations", () => {
     const rows = await query<any>("DESCRIBE task_log");
     const statusRow = rows.find((r: any) => r.Field === "status");
     expect(statusRow).toBeDefined();
+    expect(statusRow.Type).toContain("QUEUED");
     expect(statusRow.Type).toContain("RECEIVED");
     expect(statusRow.Type).toContain("CLASSIFIED");
     expect(statusRow.Type).toContain("DISPATCHED");
     expect(statusRow.Type).toContain("COMPLETED");
     expect(statusRow.Type).toContain("FAILED");
+  });
+
+  it("migration 019 adds async-pipeline columns and index to task_log", async ({ skip }) => {
+    if (!doltAvailable) skip();
+    const rows = await query<any>("DESCRIBE task_log");
+    const columns = rows.map((r: any) => r.Field);
+    for (const col of [
+      "prompt",
+      "input_metadata",
+      "input_constraints",
+      "worker_started_at",
+      "worker_finished_at",
+      "worker_error",
+      "response_content",
+    ]) {
+      expect(columns, `task_log column ${col}`).toContain(col);
+    }
+    const idx = await query<any>(
+      "SHOW INDEX FROM task_log WHERE Key_name = ?",
+      ["idx_task_log_status_created"],
+    );
+    expect(idx.length).toBeGreaterThanOrEqual(1);
   });
 
   it("routing_policy has correct columns", async ({ skip }) => {

--- a/tests/db/migrations.test.ts
+++ b/tests/db/migrations.test.ts
@@ -110,10 +110,9 @@ describe("migrations", () => {
     ]) {
       expect(columns, `task_log column ${col}`).toContain(col);
     }
-    const idx = await query<any>(
-      "SHOW INDEX FROM task_log WHERE Key_name = ?",
-      ["idx_task_log_status_created"],
-    );
+    const idx = await query<any>("SHOW INDEX FROM task_log WHERE Key_name = ?", [
+      "idx_task_log_status_created",
+    ]);
     expect(idx.length).toBeGreaterThanOrEqual(1);
   });
 

--- a/tests/services/task-worker.test.ts
+++ b/tests/services/task-worker.test.ts
@@ -122,9 +122,7 @@ describe("task-worker", () => {
     expect(finished.worker_finished_at).not.toBeNull();
   });
 
-  it("provider error → row reaches FAILED (routeTask handles its own errors)", async ({
-    skip,
-  }) => {
+  it("provider error → row reaches FAILED (routeTask handles its own errors)", async ({ skip }) => {
     if (!doltAvailable) skip();
     globalThis.fetch = vi.fn().mockImplementation(async () => ({
       ok: false,
@@ -142,9 +140,7 @@ describe("task-worker", () => {
     expect(finished.status).toBe("FAILED");
   });
 
-  it("claimQueued is idempotent — duplicate enqueue does not double-execute", async ({
-    skip,
-  }) => {
+  it("claimQueued is idempotent — duplicate enqueue does not double-execute", async ({ skip }) => {
     if (!doltAvailable) skip();
     mockProviderSuccess("once");
 

--- a/tests/services/task-worker.test.ts
+++ b/tests/services/task-worker.test.ts
@@ -96,9 +96,11 @@ afterAll(async () => {
     const pool = getPool();
     await pool.query("DELETE FROM execution_log WHERE agent_id LIKE 'wrk-test-%'");
     await pool.query("DELETE FROM task_log WHERE prompt LIKE ?", [`${TEST_PROMPT_PREFIX}%`]);
+    // Re-enable everything we disabled in beforeAll. Using the inverse of
+    // the disable query (rather than a hardcoded agent list) avoids leaving
+    // future seed agents disabled if the seed list grows.
     await pool.query(
-      `UPDATE agent_registry SET status = 'active'
-       WHERE agent_id IN ('claude-haiku-4-5','claude-sonnet-4-5','gpt-4o-mini','local-llama')`,
+      "UPDATE agent_registry SET status = 'active' WHERE agent_id NOT LIKE 'wrk-test-%'",
     );
     await pool.query("DELETE FROM agent_registry WHERE agent_id LIKE 'wrk-test-%'");
   }

--- a/tests/services/task-worker.test.ts
+++ b/tests/services/task-worker.test.ts
@@ -1,0 +1,216 @@
+import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
+import { createPool, getPool, query, destroy } from "../../src/db/connection.js";
+import { uuidv7, sha256 } from "../../src/types/task.js";
+import { loadConfig } from "../../src/config.js";
+import { runMigrations } from "../../src/db/migrate.js";
+import * as taskLog from "../../src/repositories/task-log.js";
+import * as worker from "../../src/services/task-worker.js";
+import { runReaperOnce } from "../../src/services/task-reaper.js";
+
+let doltAvailable = false;
+const originalFetch = globalThis.fetch;
+
+const TEST_PROMPT_PREFIX = "[task-worker.test] ";
+
+function mockProviderSuccess(content = "ok") {
+  globalThis.fetch = vi.fn().mockImplementation(async (url: string) => {
+    if (url.includes("anthropic.com")) {
+      return {
+        ok: true,
+        json: async () => ({
+          content: [{ text: content }],
+          usage: { input_tokens: 10, output_tokens: 5 },
+          model: "mock",
+          stop_reason: "end_turn",
+        }),
+      };
+    }
+    if (url.includes("openai.com")) {
+      return {
+        ok: true,
+        json: async () => ({
+          choices: [{ message: { content } }],
+          usage: { prompt_tokens: 10, completion_tokens: 5 },
+          model: "mock",
+        }),
+      };
+    }
+    return { ok: true, json: async () => ({ response: content, model: "mock" }) };
+  }) as unknown as typeof fetch;
+}
+
+async function pollUntilDone(taskId: string, timeoutMs = 5_000): Promise<taskLog.TaskLogRecord> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const row = await taskLog.findById(taskId);
+    if (row && (row.status === "COMPLETED" || row.status === "FAILED")) {
+      return row;
+    }
+    await new Promise((r) => setTimeout(r, 25));
+  }
+  throw new Error(`Task ${taskId} did not finish within ${timeoutMs}ms`);
+}
+
+beforeAll(async () => {
+  const config = loadConfig();
+  try {
+    getPool();
+  } catch {
+    createPool(config.dolt);
+  }
+  try {
+    await query("SELECT 1");
+    doltAvailable = true;
+    await runMigrations();
+    const pool = getPool();
+    // Seed minimal agent + policy needed by routeTask.
+    await pool.query("DELETE FROM routing_rules");
+    await pool.query("DELETE FROM routing_utterances");
+    await pool.query(
+      `INSERT IGNORE INTO routing_policy
+         (policy_id, weight_capability, weight_cost, weight_latency, fallback_strategy, max_retries, active)
+       VALUES ('default', 0.50, 0.30, 0.20, 'NEXT_BEST', 0, TRUE)`,
+    );
+    await pool.query(
+      "UPDATE agent_registry SET status = 'disabled' WHERE agent_id NOT LIKE 'wrk-test-%'",
+    );
+    await pool.query(
+      `INSERT IGNORE INTO agent_registry
+         (agent_id, provider, model_id, capabilities, cost_per_1k_input, cost_per_1k_output, max_context_tokens, avg_latency_ms, status, tier_ceiling)
+       VALUES
+         ('wrk-test-haiku', 'anthropic', 'claude-haiku-4-5-20251001',
+          '["classification","summarization","structured_output"]',
+          0.000800, 0.004000, 200000, 300, 'active', 2)`,
+    );
+  } catch {
+    console.warn("Dolt not available — skipping task-worker tests");
+  }
+  worker.start();
+});
+
+afterAll(async () => {
+  await worker.stop(2_000);
+  worker._resetForTests();
+  globalThis.fetch = originalFetch;
+  if (doltAvailable) {
+    const pool = getPool();
+    await pool.query("DELETE FROM execution_log WHERE agent_id LIKE 'wrk-test-%'");
+    await pool.query("DELETE FROM task_log WHERE prompt LIKE ?", [`${TEST_PROMPT_PREFIX}%`]);
+    await pool.query(
+      `UPDATE agent_registry SET status = 'active'
+       WHERE agent_id IN ('claude-haiku-4-5','claude-sonnet-4-5','gpt-4o-mini','local-llama')`,
+    );
+    await pool.query("DELETE FROM agent_registry WHERE agent_id LIKE 'wrk-test-%'");
+  }
+  await destroy();
+});
+
+describe("task-worker", () => {
+  it("enqueue → row reaches COMPLETED with persisted response_content", async ({ skip }) => {
+    if (!doltAvailable) skip();
+    mockProviderSuccess("worker-ran-it");
+
+    const taskId = uuidv7();
+    const prompt = `${TEST_PROMPT_PREFIX}happy path`;
+    await taskLog.createQueued(taskId, sha256(prompt), { prompt });
+    worker.enqueue(taskId, { prompt });
+
+    const finished = await pollUntilDone(taskId);
+    expect(finished.status).toBe("COMPLETED");
+    expect(finished.response_content).toBe("worker-ran-it");
+    expect(finished.worker_started_at).not.toBeNull();
+    expect(finished.worker_finished_at).not.toBeNull();
+  });
+
+  it("provider error → row reaches FAILED (routeTask handles its own errors)", async ({
+    skip,
+  }) => {
+    if (!doltAvailable) skip();
+    globalThis.fetch = vi.fn().mockImplementation(async () => ({
+      ok: false,
+      status: 500,
+      json: async () => ({ error: "boom" }),
+      text: async () => "boom",
+    })) as unknown as typeof fetch;
+
+    const taskId = uuidv7();
+    const prompt = `${TEST_PROMPT_PREFIX}provider failure`;
+    await taskLog.createQueued(taskId, sha256(prompt), { prompt });
+    worker.enqueue(taskId, { prompt });
+
+    const finished = await pollUntilDone(taskId, 8_000);
+    expect(finished.status).toBe("FAILED");
+  });
+
+  it("claimQueued is idempotent — duplicate enqueue does not double-execute", async ({
+    skip,
+  }) => {
+    if (!doltAvailable) skip();
+    mockProviderSuccess("once");
+
+    const taskId = uuidv7();
+    const prompt = `${TEST_PROMPT_PREFIX}duplicate enqueue`;
+    await taskLog.createQueued(taskId, sha256(prompt), { prompt });
+
+    worker.enqueue(taskId, { prompt });
+    worker.enqueue(taskId, { prompt });
+
+    const finished = await pollUntilDone(taskId);
+    expect(finished.status).toBe("COMPLETED");
+
+    // Only one execution row should exist.
+    const pool = getPool();
+    const [rows] = await pool.query<Array<{ n: number }> & { 0: { n: number } }>(
+      "SELECT COUNT(*) AS n FROM execution_log WHERE task_id = ?",
+      [taskId],
+    );
+    const count = (rows as unknown as Array<{ n: number }>)[0].n;
+    expect(Number(count)).toBe(1);
+  });
+});
+
+describe("task-reaper", () => {
+  it("re-enqueues stranded QUEUED rows on startup sweep", async ({ skip }) => {
+    if (!doltAvailable) skip();
+    mockProviderSuccess("recovered");
+
+    const taskId = uuidv7();
+    const prompt = `${TEST_PROMPT_PREFIX}reaper requeue`;
+    await taskLog.createQueued(taskId, sha256(prompt), { prompt });
+    // Note: we did NOT call worker.enqueue() — simulating a row that survived
+    // a process restart while still in QUEUED.
+
+    const stats = await runReaperOnce();
+    expect(stats.reEnqueued).toBeGreaterThanOrEqual(1);
+
+    const finished = await pollUntilDone(taskId);
+    expect(finished.status).toBe("COMPLETED");
+  });
+
+  it("marks stale DISPATCHED rows FAILED with worker_crashed", async ({ skip }) => {
+    if (!doltAvailable) skip();
+
+    const taskId = uuidv7();
+    const prompt = `${TEST_PROMPT_PREFIX}reaper stale dispatch`;
+    await taskLog.createQueued(taskId, sha256(prompt), { prompt });
+
+    // Force the row into a stale-DISPATCHED state by hand: bypass claimQueued
+    // and backdate created_at past the recovery threshold.
+    const pool = getPool();
+    await pool.query(
+      `UPDATE task_log
+         SET status = 'DISPATCHED',
+             selected_agent_id = 'wrk-test-haiku',
+             created_at = NOW() - INTERVAL 1 DAY
+       WHERE task_id = ?`,
+      [taskId],
+    );
+
+    const stats = await runReaperOnce();
+    expect(stats.failed).toBeGreaterThanOrEqual(1);
+
+    const row = await taskLog.findById(taskId);
+    expect(row?.status).toBe("FAILED");
+    expect(row?.worker_error).toBe("worker_crashed");
+  });
+});


### PR DESCRIPTION
## Why

`POST /tasks` blocks 15–120s waiting on the LLM (per-tier timeout), tripping load-balancer timeouts and hanging browser clients. This blocks streaming, webhooks, and any long-prompt UX.

## What changed

- `POST /tasks` validates input, allocates a `task_id`, persists a `QUEUED` row in `task_log`, hands the job to an in-process worker, and returns **202 Accepted** with `task_id` + `Location` + `Retry-After` headers.
- Clients poll `GET /tasks/:id` until `done: true`. Top-level `response_content`, `worker_started_at/finished_at`, `worker_error` are surfaced.
- New `src/services/task-worker.ts` — bounded-concurrency drain (`WORKER_CONCURRENCY`, default 4), idempotent `claimQueued` (atomic `UPDATE … WHERE status='QUEUED'`), `start`/`stop` with SIGTERM grace.
- New `src/services/task-reaper.ts` — startup sweep + 60s timer. Re-enqueues stranded `QUEUED` rows (safe — they never started). Marks rows stuck >`WORKER_RECOVERY_AGE_MS` (default 600s) in RECEIVED/CLASSIFIED/DISPATCHED as `FAILED` with `worker_error="worker_crashed"`. **No retry** for the latter — an LLM call may have already been billed; double-charging on transient crashes is worse than surfacing a clean failure.
- Migration `019_async_task_pipeline.sql`:
  - `QUEUED` appended to `task_log.status` ENUM (appended, not prepended, to preserve existing ordinals).
  - `prompt`, `input_metadata`, `input_constraints` so the reaper can rebuild input after a crash.
  - `worker_started_at`, `worker_finished_at`, `worker_error` for observability.
  - `response_content` because the winning LLM response was previously only in `routeTask`'s in-memory return value — useless for an async poller.
  - `(status, created_at)` index to keep reaper polls cheap.
- CLI now polls after the 202 (exponential backoff 250ms→2s, 180s cap) so `haol task` stays synchronous-feeling. `waitTimeoutMs: 0` opts out for fire-and-forget.

## Latent bugs surfaced & fixed

Found while wiring the live test path:

- `src/services/routing-tuner.ts` queried `t.status = 'completed'` against the uppercase `task_log.status` ENUM. Worked only because Dolt was lenient — the `ALTER TABLE … MODIFY` in 019 made it strict (`"value completed is not valid for this Enum"`). Fixed both occurrences to `'COMPLETED'`.
- `task_outcome.signal_value` was effectively `NOT NULL` despite migration 010 saying `DEFAULT NULL` (Dolt's interpretation). Application code always treated it as nullable. Migration `020_fix_signal_value_nullable.sql` widens it; unblocks the `outcomeSignalRates` IS NULL filter test and the `evaluation_failed` insert.

## Tests

`424 pass / 6 skipped / 0 fail`. New file `tests/services/task-worker.test.ts` covers happy path, provider-error → FAILED, claim idempotency under duplicate enqueue, reaper re-enqueue of stranded QUEUED, and reaper FAILED-stamp on stale DISPATCHED. Existing `tests/api/tasks.test.ts` rewritten for the 202+poll contract; `tests/cli/task.test.ts` updated to mock the POST→GET flow; `tests/db/migrations.test.ts` updated for new column/index assertions.

## Live smoke test

| | |
|---|---|
| `POST /tasks` latency | **26ms** (was 15–120s) |
| 5 concurrent POSTs | all 202 in ~20ms |
| Mid-flight `GET /tasks/:id` | shows `DISPATCHED, done: false` |
| Terminal `GET` | `done: true`, `response_content` populated, worker timestamps set |
| Negative cases | empty prompt → 400, missing id → 404 |

## Open considerations (not in this PR)

- Single-instance worker. Multi-replica deploys should swap to a Dolt-backed poll queue (`SELECT … FOR UPDATE SKIP LOCKED`) — schema is shaped for this.
- No queue-depth metric in `/health` yet; worth adding if backpressure visibility matters.
- Per-task Dolt session branches: reaper best-effort deletes them for FAILED-by-reaper rows, but a healthy crash mid-`commitSession` could still leak.

## Test plan

- [ ] CI green
- [ ] Manual: `npm run migrate` clean apply (idempotent)
- [ ] Manual: `curl -X POST /tasks` returns 202 in <100ms; `GET /tasks/:id` reaches COMPLETED with `response_content` populated
- [ ] Manual: kill the worker mid-task; restart; reaper marks the row FAILED with `worker_error="worker_crashed"` within 10 min