### PR TITLE
Track applied migrations with SHA pinning

### DIFF
--- a/src/db/migrate.ts
+++ b/src/db/migrate.ts
@@ -1,4 +1,5 @@
 import { readdir, readFile } from "node:fs/promises";
+import { createHash } from "node:crypto";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { loadConfig } from "../config.js";
@@ -8,35 +9,105 @@ import { doltCommit } from "./dolt.js";
 const __dirname = fileURLToPath(new URL(".", import.meta.url));
 const MIGRATIONS_DIR = join(__dirname, "migrations");
 
+const TRACKING_DDL = `
+  CREATE TABLE IF NOT EXISTS migrations_applied (
+    filename VARCHAR(255) NOT NULL PRIMARY KEY,
+    sha256 CHAR(64) NOT NULL,
+    applied_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6)
+  )
+`;
+
+interface AppliedRow {
+  filename: string;
+  sha256: string;
+}
+
+function sha256(content: string): string {
+  return createHash("sha256").update(content, "utf8").digest("hex");
+}
+
+async function loadAppliedRows(): Promise<Map<string, string>> {
+  const pool = getPool();
+  const [rows] = (await pool.query("SELECT filename, sha256 FROM migrations_applied")) as [
+    AppliedRow[],
+    unknown,
+  ];
+  const map = new Map<string, string>();
+  for (const row of rows) map.set(row.filename, row.sha256);
+  return map;
+}
+
+async function legacySchemaExists(): Promise<boolean> {
+  const pool = getPool();
+  // agent_registry is created by 001_create_agent_registry.sql — its presence
+  // signals that this DB was already migrated before tracking was introduced.
+  const [rows] = (await pool.query(
+    `SELECT 1 FROM INFORMATION_SCHEMA.TABLES
+     WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'agent_registry' LIMIT 1`,
+  )) as [unknown[], unknown];
+  return rows.length > 0;
+}
+
 export async function runMigrations(): Promise<string[]> {
   const files = (await readdir(MIGRATIONS_DIR)).filter((f) => f.endsWith(".sql")).sort();
-
   const pool = getPool();
-  const applied: string[] = [];
+
+  await pool.query(TRACKING_DDL);
+
+  const applied = await loadAppliedRows();
+
+  // One-time backfill: if tracking is empty but the schema is already
+  // populated, this DB pre-dates the tracking table. Stamp every current
+  // file as applied so we don't re-run non-idempotent ALTERs (e.g. 011's
+  // ADD COLUMN without IF NOT EXISTS) and trip on duplicate-column errors.
+  if (applied.size === 0 && (await legacySchemaExists())) {
+    console.log("[migrate] existing schema detected — backfilling migrations_applied");
+    for (const file of files) {
+      const sql = await readFile(join(MIGRATIONS_DIR, file), "utf8");
+      const hash = sha256(sql);
+      await pool.query("INSERT INTO migrations_applied (filename, sha256) VALUES (?, ?)", [
+        file,
+        hash,
+      ]);
+    }
+    return [];
+  }
+
+  const ran: string[] = [];
 
   for (const file of files) {
-    const sql = await readFile(join(MIGRATIONS_DIR, file), "utf-8");
+    const sql = await readFile(join(MIGRATIONS_DIR, file), "utf8");
+    const hash = sha256(sql);
+    const recordedHash = applied.get(file);
+
+    if (recordedHash) {
+      if (recordedHash !== hash) {
+        throw new Error(
+          `Migration ${file} has drifted: applied SHA ${recordedHash.slice(0, 12)}… ` +
+            `does not match disk SHA ${hash.slice(0, 12)}…. ` +
+            `Revert the file or write a new migration instead of editing applied SQL.`,
+        );
+      }
+      continue;
+    }
+
     const statements = sql
       .split(";")
       .map((s) => s.trim())
       .filter((s) => s.length > 0);
 
     for (const statement of statements) {
-      try {
-        await pool.query(statement);
-      } catch (err: unknown) {
-        const msg = (err as { sqlMessage?: string }).sqlMessage ?? "";
-        // Skip "already exists" / "duplicate" errors for idempotent reruns
-        if (msg.includes("already exists") || msg.includes("Duplicate")) {
-          continue;
-        }
-        throw err;
-      }
+      await pool.query(statement);
     }
-    applied.push(file);
+
+    await pool.query("INSERT INTO migrations_applied (filename, sha256) VALUES (?, ?)", [
+      file,
+      hash,
+    ]);
+    ran.push(file);
   }
 
-  return applied;
+  return ran;
 }
 
 // CLI entry point
@@ -49,9 +120,13 @@ async function main() {
   }
 
   console.log("Running migrations...");
-  const applied = await runMigrations();
-  for (const file of applied) {
-    console.log("  applied: %s", file);
+  const ran = await runMigrations();
+  if (ran.length === 0) {
+    console.log("  no new migrations to apply.");
+  } else {
+    for (const file of ran) {
+      console.log("  applied: %s", file);
+    }
   }
 
   try {

--- a/src/db/migrate.ts
+++ b/src/db/migrate.ts
@@ -22,7 +22,7 @@ interface AppliedRow {
   sha256: string;
 }
 
-function sha256(content: string): string {
+export function sha256(content: string): string {
   return createHash("sha256").update(content, "utf8").digest("hex");
 }
 
@@ -60,16 +60,19 @@ export async function runMigrations(): Promise<string[]> {
   // populated, this DB pre-dates the tracking table. Stamp every current
   // file as applied so we don't re-run non-idempotent ALTERs (e.g. 011's
   // ADD COLUMN without IF NOT EXISTS) and trip on duplicate-column errors.
+  //
+  // The insert is a single multi-row statement so a crash mid-backfill
+  // can't leave tracking partially populated — partial rows would defeat
+  // the `applied.size === 0` guard on the next run, causing un-stamped
+  // files to be treated as "new" and re-executed.
   if (applied.size === 0 && (await legacySchemaExists())) {
     console.log("[migrate] existing schema detected — backfilling migrations_applied");
+    const rows: [string, string][] = [];
     for (const file of files) {
       const sql = await readFile(join(MIGRATIONS_DIR, file), "utf8");
-      const hash = sha256(sql);
-      await pool.query("INSERT INTO migrations_applied (filename, sha256) VALUES (?, ?)", [
-        file,
-        hash,
-      ]);
+      rows.push([file, sha256(sql)]);
     }
+    await pool.query("INSERT INTO migrations_applied (filename, sha256) VALUES ?", [rows]);
     return [];
   }
 

--- a/src/db/migrate.ts
+++ b/src/db/migrate.ts
@@ -56,6 +56,17 @@ export async function runMigrations(): Promise<string[]> {
 
   const applied = await loadAppliedRows();
 
+  // Warn on tracked files that have disappeared from disk. Operators may
+  // intentionally delete archived migrations (so warn rather than throw),
+  // but a silent accidental deletion would hide the fact that part of the
+  // applied schema no longer has a source-of-truth file.
+  const onDisk = new Set(files);
+  for (const recorded of applied.keys()) {
+    if (!onDisk.has(recorded)) {
+      console.warn("[migrate] applied migration %s no longer exists on disk", recorded);
+    }
+  }
+
   // One-time backfill: if tracking is empty but the schema is already
   // populated, this DB pre-dates the tracking table. Stamp every current
   // file as applied so we don't re-run non-idempotent ALTERs (e.g. 011's
@@ -99,6 +110,14 @@ export async function runMigrations(): Promise<string[]> {
       .map((s) => s.trim())
       .filter((s) => s.length > 0);
 
+    // Residual atomicity gap: DDL auto-commits in MySQL/Dolt, so a crash
+    // between the last statement here and the tracking INSERT below leaves
+    // the schema mutated but unrecorded. The next run will treat this file
+    // as new and re-execute it, which fails loudly (e.g. "Duplicate column"
+    // on ALTER TABLE ADD COLUMN) — the operator must then either revert
+    // the schema change or manually INSERT the tracking row. Acceptable
+    // because the failure is loud, not silent, and current migrations are
+    // DDL-only or use idempotent INSERT IGNORE / ON DUPLICATE KEY UPDATE.
     for (const statement of statements) {
       await pool.query(statement);
     }

--- a/tests/db/migrations.test.ts
+++ b/tests/db/migrations.test.ts
@@ -1,7 +1,20 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { createHash } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { createPool, getPool, query, destroy } from "../../src/db/connection.js";
 import { runMigrations } from "../../src/db/migrate.js";
 import { loadConfig } from "../../src/config.js";
+
+const MIGRATIONS_DIR = join(
+  fileURLToPath(new URL(".", import.meta.url)),
+  "../../src/db/migrations",
+);
+
+function sha256(content: string): string {
+  return createHash("sha256").update(content, "utf8").digest("hex");
+}
 
 let doltAvailable = false;
 
@@ -38,17 +51,36 @@ afterAll(async () => {
 describe("migrations", () => {
   it("applies all migration files without error", async ({ skip }) => {
     if (!doltAvailable) skip();
-    const applied = await runMigrations();
-    expect(applied.length).toBe(20);
-    expect(applied[0]).toBe("001_create_agent_registry.sql");
-    expect(applied[19]).toBe("020_fix_signal_value_nullable.sql");
+    // First call either runs all 20 (fresh DB) or backfills tracking from
+    // an existing populated DB and returns an empty list. Either way the
+    // post-condition is "every file recorded in migrations_applied."
+    await runMigrations();
+    const rows = await query<{ filename: string }>(
+      "SELECT filename FROM migrations_applied ORDER BY filename",
+    );
+    expect(rows.length).toBe(20);
+    expect(rows[0].filename).toBe("001_create_agent_registry.sql");
+    expect(rows[19].filename).toBe("020_fix_signal_value_nullable.sql");
   });
 
-  it("is idempotent — running twice produces no errors", async ({ skip }) => {
+  it("is idempotent — second run does no work", async ({ skip }) => {
     if (!doltAvailable) skip();
-    // Second run should not throw
-    const applied = await runMigrations();
-    expect(applied.length).toBe(20);
+    const ran = await runMigrations();
+    expect(ran.length).toBe(0);
+  });
+
+  it("detects drift when an applied migration's SHA differs from disk", async ({ skip }) => {
+    if (!doltAvailable) skip();
+    const file = "020_fix_signal_value_nullable.sql";
+    const onDisk = await readFile(join(MIGRATIONS_DIR, file), "utf8");
+    const realSha = sha256(onDisk);
+    const fakeSha = "0".repeat(64);
+    try {
+      await query("UPDATE migrations_applied SET sha256 = ? WHERE filename = ?", [fakeSha, file]);
+      await expect(runMigrations()).rejects.toThrow(/drifted/);
+    } finally {
+      await query("UPDATE migrations_applied SET sha256 = ? WHERE filename = ?", [realSha, file]);
+    }
   });
 
   it("creates expected tables", async ({ skip }) => {

--- a/tests/db/migrations.test.ts
+++ b/tests/db/migrations.test.ts
@@ -1,20 +1,15 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
-import { createHash } from "node:crypto";
-import { readFile } from "node:fs/promises";
+import { readdir, readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { createPool, getPool, query, destroy } from "../../src/db/connection.js";
-import { runMigrations } from "../../src/db/migrate.js";
+import { runMigrations, sha256 } from "../../src/db/migrate.js";
 import { loadConfig } from "../../src/config.js";
 
 const MIGRATIONS_DIR = join(
   fileURLToPath(new URL(".", import.meta.url)),
   "../../src/db/migrations",
 );
-
-function sha256(content: string): string {
-  return createHash("sha256").update(content, "utf8").digest("hex");
-}
 
 let doltAvailable = false;
 
@@ -80,6 +75,33 @@ describe("migrations", () => {
       await expect(runMigrations()).rejects.toThrow(/drifted/);
     } finally {
       await query("UPDATE migrations_applied SET sha256 = ? WHERE filename = ?", [realSha, file]);
+    }
+  });
+
+  it("backfills tracking when schema is populated but migrations_applied is empty", async ({
+    skip,
+  }) => {
+    if (!doltAvailable) skip();
+    const sqlFiles = (await readdir(MIGRATIONS_DIR)).filter((f) => f.endsWith(".sql")).sort();
+    const expected = new Map<string, string>();
+    for (const file of sqlFiles) {
+      expected.set(file, sha256(await readFile(join(MIGRATIONS_DIR, file), "utf8")));
+    }
+
+    // Wipe tracking — simulates a DB that pre-dates this PR. agent_registry
+    // (created by 001) still exists, so the runner should detect legacy
+    // schema and backfill rather than re-running ALTERs.
+    await query("DELETE FROM migrations_applied");
+
+    const ran = await runMigrations();
+    expect(ran.length).toBe(0);
+
+    const rows = await query<{ filename: string; sha256: string }>(
+      "SELECT filename, sha256 FROM migrations_applied ORDER BY filename",
+    );
+    expect(rows.length).toBe(sqlFiles.length);
+    for (const row of rows) {
+      expect(row.sha256).toBe(expected.get(row.filename));
     }
   });
 


### PR DESCRIPTION
## Summary

- Adds a `migrations_applied(filename, sha256, applied_at)` table so the runner can tell which migrations have already been applied and refuse to start when a recorded migration's SHA differs from disk.
- Drops the `"already exists" / "Duplicate"` error swallow that was masking partial applies and silent drift across environments.
- Backfills tracking on first run against existing populated DBs (detected via `agent_registry`) so non-idempotent ALTERs (e.g. `011`'s `ADD COLUMN`) don't re-execute.

## Why

The previous runner re-iterated every file on each invocation and relied on swallowing duplicate-table / duplicate-column errors to act idempotent. That approach has two real failure modes:

1. **Non-idempotent statements aren't covered.** Plain `INSERT` / additive `UPDATE` would silently double-apply.
2. **Partial-apply detection is impossible.** If statement N of a multi-statement file fails, statements 1..N-1 stay applied and the next run re-executes them under the swallow, hiding real failures.

SHA pinning + an applied-migrations log is the standard fix (Flyway, Liquibase, sqlx-cli) and additionally catches the "someone edited a migration file after it was applied" failure mode.

## Notes for reviewers

- Existing populated DBs are auto-stamped on first run after this lands. The trigger is `migrations_applied` empty AND `agent_registry` exists. The CLI logs `[migrate] existing schema detected — backfilling migrations_applied` when it fires.
- The `split(";")` statement splitter is unchanged. None of the current 20 migration files contain semicolons inside strings/comments/`DELIMITER` blocks, so it isn't currently broken — leaving the hardening to a follow-up when a migration actually needs it.

## Test plan

- [x] `npm run build` — clean.
- [x] `npx vitest run` — 266 pass, 165 skip (no Dolt locally; tests skip-gracefully as designed).
- [ ] Run `npm run migrate` against a Dolt instance with the existing schema — verify backfill log fires once and second run reports `no new migrations to apply.`
- [ ] On a fresh DB, run `npm run migrate` — verify all 20 files apply and `migrations_applied` is populated with matching SHAs.
- [ ] Mutate a row in `migrations_applied` (set sha256 to a wrong value) and rerun — verify the runner refuses to start with a `drifted` error.