### PR TITLE
Mount API under /v1 for stable contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,7 +350,7 @@ When a task includes an `expected_format` spec, the pipeline programmatically ve
 To use Tier 1, include `expected_format` in your task submission:
 
 ```bash
-curl -X POST http://localhost:3000/tasks \
+curl -X POST http://localhost:3000/v1/tasks \
   -H "Content-Type: application/json" \
   -d '{
     "prompt": "Return a JSON object with title, summary, and tags",
@@ -377,7 +377,7 @@ Ground-truth signals from systems or humans that consume HAOL's output. These ar
 
 ```bash
 # Report a positive outcome
-curl -X POST http://localhost:3000/tasks/<task_id>/outcome \
+curl -X POST http://localhost:3000/v1/tasks/<task_id>/outcome \
   -H "Content-Type: application/json" \
   -d '{
     "signal_type": "user_satisfied",
@@ -387,7 +387,7 @@ curl -X POST http://localhost:3000/tasks/<task_id>/outcome \
   }'
 
 # Report a negative outcome
-curl -X POST http://localhost:3000/tasks/<task_id>/outcome \
+curl -X POST http://localhost:3000/v1/tasks/<task_id>/outcome \
   -H "Content-Type: application/json" \
   -d '{
     "signal_type": "output_rejected",
@@ -401,13 +401,13 @@ curl -X POST http://localhost:3000/tasks/<task_id>/outcome \
 
 ```bash
 # All outcomes for a task
-curl http://localhost:3000/tasks/<task_id>/outcomes
+curl http://localhost:3000/v1/tasks/<task_id>/outcomes
 
 # Filter by tier
-curl http://localhost:3000/tasks/<task_id>/outcomes?tier=0
+curl http://localhost:3000/v1/tasks/<task_id>/outcomes?tier=0
 
 # Aggregated summary
-curl http://localhost:3000/tasks/<task_id>/outcomes/summary
+curl http://localhost:3000/v1/tasks/<task_id>/outcomes/summary
 ```
 
 The summary endpoint returns signal counts broken down by tier:
@@ -451,10 +451,10 @@ Two observability endpoints aggregate outcome data across all tasks:
 
 ```bash
 # Signal pass/fail rates by type (last 24 hours)
-curl http://localhost:3000/stats/outcomes?hours=24
+curl http://localhost:3000/v1/observability/stats/outcomes?hours=24
 
 # Per-agent routing accuracy from Tier 2+3 signals
-curl http://localhost:3000/stats/routing-accuracy?hours=24
+curl http://localhost:3000/v1/observability/stats/routing-accuracy?hours=24
 ```
 
 ### Cascade router observability
@@ -467,17 +467,17 @@ Two endpoints aggregate `routing_log` so you can see how the cascade is performi
 # (decisions where the semantic layer was consulted but did not resolve,
 # sorted by similarity_score DESC — these are the most informative for
 # tuning similarity_threshold).
-curl http://localhost:3000/observability/cascade?hours=24
+curl http://localhost:3000/v1/observability/cascade?hours=24
 
 # Time-series: bucketed escalation_rate, fallback_rate, total volume,
 # and avg_latency_ms over time. bucket=hour (default) or bucket=day.
-curl http://localhost:3000/observability/cascade/timeseries?hours=72&bucket=hour
+curl http://localhost:3000/v1/observability/cascade/timeseries?hours=72&bucket=hour
 
 # Near-misses include only a SHA-256 hash of the input prompt by default,
 # so observability access (which is auth-gated) doesn't double as a PII
 # firehose for whoever holds the API key. Pass include_text=true to opt
 # into raw prompt content for ad-hoc debugging.
-curl http://localhost:3000/observability/cascade?hours=24&include_text=true
+curl http://localhost:3000/v1/observability/cascade?hours=24&include_text=true
 ```
 
 Snapshot response shape:
@@ -583,13 +583,13 @@ Via API:
 
 ```bash
 # Dry run
-curl -X POST "http://localhost:3000/observability/tune?hours=72&dry_run=true"
+curl -X POST "http://localhost:3000/v1/observability/tune?hours=72&dry_run=true"
 
 # Live run
-curl -X POST "http://localhost:3000/observability/tune?hours=72"
+curl -X POST "http://localhost:3000/v1/observability/tune?hours=72"
 
 # Tuning history
-curl "http://localhost:3000/observability/tune/history?limit=10"
+curl "http://localhost:3000/v1/observability/tune/history?limit=10"
 ```
 
 ### Configuration
@@ -767,30 +767,30 @@ Tests skip gracefully when Dolt is unavailable. The cascade router has full unit
 
 ```bash
 # Submit a task
-curl -X POST http://localhost:3000/tasks \
+curl -X POST http://localhost:3000/v1/tasks \
   -H "Content-Type: application/json" \
   -d '{"prompt": "Summarize the key points of this article..."}'
 
 # Submit with tier override
-curl -X POST http://localhost:3000/tasks \
+curl -X POST http://localhost:3000/v1/tasks \
   -H "Content-Type: application/json" \
   -d '{"prompt": "Hello", "metadata": {"tier": 4}}'
 
 # Check task status
-curl http://localhost:3000/tasks/<task_id>
+curl http://localhost:3000/v1/tasks/<task_id>
 ```
 
 ### Agent Management
 
 ```bash
 # List agents
-curl http://localhost:3000/agents
+curl http://localhost:3000/v1/agents
 
 # Filter by capability
-curl http://localhost:3000/agents?capability=code_generation
+curl http://localhost:3000/v1/agents?capability=code_generation
 
 # Register an agent
-curl -X POST http://localhost:3000/agents \
+curl -X POST http://localhost:3000/v1/agents \
   -H "Content-Type: application/json" \
   -d '{
     "agent_id": "claude-sonnet",
@@ -807,27 +807,27 @@ curl -X POST http://localhost:3000/agents \
 
 ```bash
 # Dashboard overview
-curl http://localhost:3000/stats
+curl http://localhost:3000/v1/observability/stats
 
 # Cost, latency, failures, tiers, breaches
-curl http://localhost:3000/stats/cost?hours=24
-curl http://localhost:3000/stats/latency?hours=24
-curl http://localhost:3000/stats/failures?hours=24
-curl http://localhost:3000/stats/tiers?hours=24
-curl http://localhost:3000/stats/breaches
+curl http://localhost:3000/v1/observability/stats/cost?hours=24
+curl http://localhost:3000/v1/observability/stats/latency?hours=24
+curl http://localhost:3000/v1/observability/stats/failures?hours=24
+curl http://localhost:3000/v1/observability/stats/tiers?hours=24
+curl http://localhost:3000/v1/observability/stats/breaches
 
 # Outcome signals and routing accuracy
-curl http://localhost:3000/stats/outcomes?hours=24
-curl http://localhost:3000/stats/routing-accuracy?hours=24
+curl http://localhost:3000/v1/observability/stats/outcomes?hours=24
+curl http://localhost:3000/v1/observability/stats/routing-accuracy?hours=24
 
 # Routing tuner
-curl -X POST "http://localhost:3000/observability/tune?hours=72"
-curl -X POST "http://localhost:3000/observability/tune?dry_run=true"
-curl http://localhost:3000/observability/tune/history?limit=10
+curl -X POST "http://localhost:3000/v1/observability/tune?hours=72"
+curl -X POST "http://localhost:3000/v1/observability/tune?dry_run=true"
+curl http://localhost:3000/v1/observability/tune/history?limit=10
 
 # Audit trail
-curl http://localhost:3000/audit/commits?limit=50
-curl http://localhost:3000/audit/agents?since=7d
+curl http://localhost:3000/v1/observability/audit/commits?limit=50
+curl http://localhost:3000/v1/observability/audit/agents?since=7d
 ```
 
 ### Health Check

--- a/scripts/load-test.ts
+++ b/scripts/load-test.ts
@@ -348,7 +348,7 @@ async function fetchAgentCapabilities(): Promise<Map<string, string[]>> {
   // against the chosen agent's configured capability set. Returns an empty map
   // on any failure — capability checks are skipped, tier checks still run.
   try {
-    const resp = await fetch(`${BASE_URL}/agents`, { headers: authHeaders() });
+    const resp = await fetch(`${BASE_URL}/v1/agents`, { headers: authHeaders() });
     if (!resp.ok) return new Map();
     const body = (await resp.json()) as { agent_id: string; capabilities: string[] }[];
     return new Map(body.map((a) => [a.agent_id, a.capabilities ?? []]));
@@ -366,7 +366,7 @@ async function submitTask(scenario: Scenario): Promise<ScenarioResult> {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), scenarioTimeout + 5_000);
   try {
-    const resp = await fetch(`${BASE_URL}/tasks`, {
+    const resp = await fetch(`${BASE_URL}/v1/tasks`, {
       method: "POST",
       headers: authHeaders(),
       body: JSON.stringify(scenario.request),

--- a/src/api/app.ts
+++ b/src/api/app.ts
@@ -41,30 +41,32 @@ export function createApp(): Hono {
   );
   app.route("/", demo);
 
-  // Health check is unauthenticated (load balancers, K8s probes)
+  // Health check is unversioned (load balancers, K8s probes) and unauthenticated.
+  // Reserved unversioned root for cross-version concerns (health, future
+  // discovery endpoints) — versioned API surface lives under /v1.
   app.route("/", health);
 
   // Protected routes require API key auth (when HAOL_API_KEY is set)
-  app.use("/tasks/*", apiKeyAuth);
-  app.use("/agents/*", apiKeyAuth);
-  app.use("/observability/*", apiKeyAuth);
+  app.use("/v1/tasks/*", apiKeyAuth);
+  app.use("/v1/agents/*", apiKeyAuth);
+  app.use("/v1/observability/*", apiKeyAuth);
 
   // Rate limiting — applied after auth so unauthenticated requests
   // are rejected before consuming rate-limit tokens.
   // Use wildcard patterns so future sub-routes are also covered.
-  app.post("/tasks/*", taskWriteLimit);
-  app.post("/observability/tune", tuneLimit);
+  app.post("/v1/tasks/*", taskWriteLimit);
+  app.post("/v1/observability/tune", tuneLimit);
 
   // Read limiters use app.get() so they don't double-count POST requests
   // that already have their own write limiters above.
-  app.get("/tasks/*", readLimit);
-  app.get("/agents/*", readLimit);
-  app.get("/observability/*", readLimit);
+  app.get("/v1/tasks/*", readLimit);
+  app.get("/v1/agents/*", readLimit);
+  app.get("/v1/observability/*", readLimit);
 
-  app.route("/", agents);
-  app.route("/", tasks);
-  app.route("/observability", observability);
-  app.route("/", outcomes);
+  app.route("/v1", agents);
+  app.route("/v1", tasks);
+  app.route("/v1/observability", observability);
+  app.route("/v1", outcomes);
 
   // Error handler
   app.onError(errorHandler);

--- a/src/api/routes/tasks.ts
+++ b/src/api/routes/tasks.ts
@@ -48,13 +48,13 @@ tasks.post("/tasks", async (c) => {
     return c.json({ error: "task queue unavailable, retry shortly" }, 503);
   }
 
-  c.header("Location", `/tasks/${taskId}`);
+  c.header("Location", `/v1/tasks/${taskId}`);
   c.header("Retry-After", "1");
   return c.json(
     {
       task_id: taskId,
       status: "QUEUED",
-      links: { self: `/tasks/${taskId}` },
+      links: { self: `/v1/tasks/${taskId}` },
     },
     202,
   );

--- a/src/cli/commands/agents.ts
+++ b/src/cli/commands/agents.ts
@@ -27,7 +27,7 @@ export async function agentsListCommand(opts: AgentsListOptions): Promise<string
   const params = new URLSearchParams();
   if (opts.status) params.set("status", opts.status);
   const qs = params.toString();
-  const url = `${opts.baseUrl}/agents${qs ? "?" + qs : ""}`;
+  const url = `${opts.baseUrl}/v1/agents${qs ? "?" + qs : ""}`;
 
   const res = await fetch(url);
   const data = await res.json();
@@ -52,7 +52,7 @@ export async function agentsUpdateCommand(opts: AgentsUpdateOptions): Promise<st
   const body: Record<string, unknown> = {};
   if (opts.status) body.status = opts.status;
 
-  const res = await fetch(`${opts.baseUrl}/agents/${opts.agentId}`, {
+  const res = await fetch(`${opts.baseUrl}/v1/agents/${opts.agentId}`, {
     method: "PUT",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(body),
@@ -73,7 +73,7 @@ export async function agentsRemoveCommand(
   baseUrl: string,
   format: OutputFormat,
 ): Promise<string> {
-  const res = await fetch(`${baseUrl}/agents/${agentId}`, {
+  const res = await fetch(`${baseUrl}/v1/agents/${agentId}`, {
     method: "DELETE",
   });
 

--- a/src/cli/commands/audit.ts
+++ b/src/cli/commands/audit.ts
@@ -14,7 +14,7 @@ export interface AuditCommitsOptions {
 
 export async function auditAgentsCommand(opts: AuditAgentsOptions): Promise<string> {
   const since = opts.since ?? "7d";
-  const res = await fetch(`${opts.baseUrl}/observability/audit/agents?since=${since}`);
+  const res = await fetch(`${opts.baseUrl}/v1/observability/audit/agents?since=${since}`);
   const data = await res.json();
 
   if (!res.ok) {
@@ -35,7 +35,7 @@ export async function auditAgentsCommand(opts: AuditAgentsOptions): Promise<stri
 
 export async function auditCommitsCommand(opts: AuditCommitsOptions): Promise<string> {
   const limit = opts.last ?? 20;
-  const res = await fetch(`${opts.baseUrl}/observability/audit/commits?limit=${limit}`);
+  const res = await fetch(`${opts.baseUrl}/v1/observability/audit/commits?limit=${limit}`);
   const data = await res.json();
 
   if (!res.ok) {

--- a/src/cli/commands/history.ts
+++ b/src/cli/commands/history.ts
@@ -16,7 +16,7 @@ export async function historyCommand(opts: HistoryCommandOptions): Promise<strin
   if (opts.agent) params.set("agent", opts.agent);
   const qs = params.toString();
 
-  const res = await fetch(`${opts.baseUrl}/observability/audit/commits${qs ? "?" + qs : ""}`);
+  const res = await fetch(`${opts.baseUrl}/v1/observability/audit/commits${qs ? "?" + qs : ""}`);
 
   if (!res.ok) {
     // Fallback: audit endpoint may not exist yet (Story 10)

--- a/src/cli/commands/stats.ts
+++ b/src/cli/commands/stats.ts
@@ -8,7 +8,7 @@ export interface StatsCommandOptions {
 
 export async function statsCommand(opts: StatsCommandOptions): Promise<string> {
   const hours = opts.hours ?? 24;
-  const res = await fetch(`${opts.baseUrl}/observability/stats?hours=${hours}`);
+  const res = await fetch(`${opts.baseUrl}/v1/observability/stats?hours=${hours}`);
   const data = await res.json();
 
   if (!res.ok) {

--- a/src/cli/commands/status.ts
+++ b/src/cli/commands/status.ts
@@ -7,7 +7,7 @@ export interface StatusCommandOptions {
 }
 
 export async function statusCommand(opts: StatusCommandOptions): Promise<string> {
-  const res = await fetch(`${opts.baseUrl}/tasks/${opts.taskId}`);
+  const res = await fetch(`${opts.baseUrl}/v1/tasks/${opts.taskId}`);
   const data = await res.json();
 
   if (!res.ok && opts.format !== "json") {

--- a/src/cli/commands/task.ts
+++ b/src/cli/commands/task.ts
@@ -31,7 +31,7 @@ async function pollTask(baseUrl: string, taskId: string, timeoutMs: number): Pro
   while (Date.now() < deadline) {
     let res: Response;
     try {
-      res = await fetch(`${baseUrl}/tasks/${taskId}`);
+      res = await fetch(`${baseUrl}/v1/tasks/${taskId}`);
     } catch (err) {
       // Network error — surface immediately rather than spinning to deadline.
       return { task_id: taskId, error: `poll request failed: ${(err as Error).message}` };
@@ -71,7 +71,7 @@ export async function taskCommand(opts: TaskCommandOptions): Promise<string> {
       (body.metadata as Record<string, unknown>).capabilities = opts.capabilities;
   }
 
-  const res = await fetch(`${opts.baseUrl}/tasks`, {
+  const res = await fetch(`${opts.baseUrl}/v1/tasks`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(body),

--- a/src/cli/commands/tune.ts
+++ b/src/cli/commands/tune.ts
@@ -18,7 +18,7 @@ async function safeJson(res: Response): Promise<Record<string, unknown>> {
 export async function tuneCommand(opts: TuneCommandOptions): Promise<string> {
   const hours = opts.hours ?? 72;
   const dryRun = opts.dryRun ? "&dry_run=true" : "";
-  const res = await fetch(`${opts.baseUrl}/observability/tune?hours=${hours}${dryRun}`, {
+  const res = await fetch(`${opts.baseUrl}/v1/observability/tune?hours=${hours}${dryRun}`, {
     method: "POST",
   });
   const data = await safeJson(res);
@@ -87,7 +87,7 @@ export interface TuneHistoryCommandOptions {
 
 export async function tuneHistoryCommand(opts: TuneHistoryCommandOptions): Promise<string> {
   const limit = opts.last ?? 10;
-  const res = await fetch(`${opts.baseUrl}/observability/tune/history?limit=${limit}`);
+  const res = await fetch(`${opts.baseUrl}/v1/observability/tune/history?limit=${limit}`);
   const data = await safeJson(res);
 
   if (!res.ok) {

--- a/tests/api/agents.test.ts
+++ b/tests/api/agents.test.ts
@@ -38,7 +38,7 @@ describe("POST /agents", () => {
   it("creates an agent with valid body → 201", async ({ skip }) => {
     if (!doltAvailable) skip();
 
-    const res = await app.request("/agents", {
+    const res = await app.request("/v1/agents", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
@@ -62,7 +62,7 @@ describe("POST /agents", () => {
   it("rejects invalid body → 400", async ({ skip }) => {
     if (!doltAvailable) skip();
 
-    const res = await app.request("/agents", {
+    const res = await app.request("/v1/agents", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ agent_id: "bad" }),
@@ -76,7 +76,7 @@ describe("GET /agents", () => {
   it("lists all agents", async ({ skip }) => {
     if (!doltAvailable) skip();
 
-    const res = await app.request("/agents");
+    const res = await app.request("/v1/agents");
     expect(res.status).toBe(200);
 
     const body = await res.json();
@@ -87,7 +87,7 @@ describe("GET /agents", () => {
   it("filters by capability query param", async ({ skip }) => {
     if (!doltAvailable) skip();
 
-    const res = await app.request("/agents?capability=summarization");
+    const res = await app.request("/v1/agents?capability=summarization");
     expect(res.status).toBe(200);
 
     const body = await res.json();
@@ -102,7 +102,7 @@ describe("PUT /agents/:id", () => {
   it("updates agent fields → 200", async ({ skip }) => {
     if (!doltAvailable) skip();
 
-    const res = await app.request(`/agents/${testAgentId}`, {
+    const res = await app.request(`/v1/agents/${testAgentId}`, {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ avg_latency_ms: 999 }),
@@ -116,7 +116,7 @@ describe("PUT /agents/:id", () => {
   it("returns 404 for non-existent agent", async ({ skip }) => {
     if (!doltAvailable) skip();
 
-    const res = await app.request("/agents/non-existent-agent", {
+    const res = await app.request("/v1/agents/non-existent-agent", {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ avg_latency_ms: 100 }),
@@ -130,14 +130,14 @@ describe("DELETE /agents/:id", () => {
   it("soft-deletes an agent → 200", async ({ skip }) => {
     if (!doltAvailable) skip();
 
-    const res = await app.request(`/agents/${testAgentId}`, {
+    const res = await app.request(`/v1/agents/${testAgentId}`, {
       method: "DELETE",
     });
 
     expect(res.status).toBe(200);
 
     // Verify agent is disabled
-    const getRes = await app.request("/agents?status=disabled");
+    const getRes = await app.request("/v1/agents?status=disabled");
     const body = await getRes.json();
     const disabled = body.find((a: Record<string, unknown>) => a.agent_id === testAgentId);
     expect(disabled).toBeTruthy();
@@ -147,7 +147,7 @@ describe("DELETE /agents/:id", () => {
   it("returns 404 for non-existent agent", async ({ skip }) => {
     if (!doltAvailable) skip();
 
-    const res = await app.request("/agents/non-existent-agent", {
+    const res = await app.request("/v1/agents/non-existent-agent", {
       method: "DELETE",
     });
 

--- a/tests/api/observability-cascade.test.ts
+++ b/tests/api/observability-cascade.test.ts
@@ -78,7 +78,7 @@ describe("GET /observability/cascade", () => {
     const pool = getPool();
     await pool.query("DELETE FROM routing_log WHERE input_text LIKE ?", [`${TEST_INPUT_PREFIX}%`]);
 
-    const res = await app.request("/observability/cascade?hours=1");
+    const res = await app.request("/v1/observability/cascade?hours=1");
     expect(res.status).toBe(200);
     const body = (await res.json()) as Record<string, unknown>;
     expect(body).toHaveProperty("window_hours", 1);
@@ -114,7 +114,7 @@ describe("GET /observability/cascade", () => {
       { layer: "fallback", tier: 3, latency: 0, conf: 0, sim: null },
     ]);
 
-    const res = await app.request("/observability/cascade?hours=1");
+    const res = await app.request("/v1/observability/cascade?hours=1");
     expect(res.status).toBe(200);
     const body = (await res.json()) as {
       total_decisions: number;
@@ -154,7 +154,7 @@ describe("GET /observability/cascade", () => {
     await pool.query("DELETE FROM routing_log WHERE input_text LIKE ?", [`${TEST_INPUT_PREFIX}%`]);
     await seedRoutingLog([{ layer: "escalation", tier: 3, latency: 450, conf: 0.85, sim: 0.4 }]);
 
-    const res = await app.request("/observability/cascade?hours=1&include_text=true");
+    const res = await app.request("/v1/observability/cascade?hours=1&include_text=true");
     expect(res.status).toBe(200);
     const body = (await res.json()) as {
       near_misses: Array<{ input_text_sha256: string; input_text?: string }>;
@@ -166,7 +166,7 @@ describe("GET /observability/cascade", () => {
 
   it("clamps the hours parameter to the valid range", async ({ skip }) => {
     if (!doltAvailable) skip();
-    const res = await app.request("/observability/cascade?hours=999999999");
+    const res = await app.request("/v1/observability/cascade?hours=999999999");
     expect(res.status).toBe(200);
     const body = (await res.json()) as { window_hours: number };
     expect(body.window_hours).toBe(8760); // MAX_HOURS
@@ -176,7 +176,7 @@ describe("GET /observability/cascade", () => {
 describe("GET /observability/cascade/timeseries", () => {
   it("returns hourly buckets by default", async ({ skip }) => {
     if (!doltAvailable) skip();
-    const res = await app.request("/observability/cascade/timeseries?hours=1");
+    const res = await app.request("/v1/observability/cascade/timeseries?hours=1");
     expect(res.status).toBe(200);
     const body = (await res.json()) as { bucket_hours: number; buckets: unknown[] };
     expect(body.bucket_hours).toBe(1);
@@ -185,7 +185,7 @@ describe("GET /observability/cascade/timeseries", () => {
 
   it("accepts bucket=day", async ({ skip }) => {
     if (!doltAvailable) skip();
-    const res = await app.request("/observability/cascade/timeseries?hours=24&bucket=day");
+    const res = await app.request("/v1/observability/cascade/timeseries?hours=24&bucket=day");
     expect(res.status).toBe(200);
     const body = (await res.json()) as { bucket_hours: number };
     expect(body.bucket_hours).toBe(24);
@@ -193,7 +193,7 @@ describe("GET /observability/cascade/timeseries", () => {
 
   it("rejects unsupported bucket values with 400", async ({ skip }) => {
     if (!doltAvailable) skip();
-    const res = await app.request("/observability/cascade/timeseries?bucket=minute");
+    const res = await app.request("/v1/observability/cascade/timeseries?bucket=minute");
     expect(res.status).toBe(400);
     const body = (await res.json()) as { error: string };
     expect(body.error).toMatch(/bucket/);

--- a/tests/api/observability-maintenance.test.ts
+++ b/tests/api/observability-maintenance.test.ts
@@ -80,9 +80,12 @@ describe("POST /observability/maintenance/cleanup-pending", () => {
   it("accepts max_age_hours parameter", async ({ skip }) => {
     if (!doltAvailable) skip();
 
-    const res = await app.request("/v1/observability/maintenance/cleanup-pending?max_age_hours=48", {
-      method: "POST",
-    });
+    const res = await app.request(
+      "/v1/observability/maintenance/cleanup-pending?max_age_hours=48",
+      {
+        method: "POST",
+      },
+    );
     expect(res.status).toBe(200);
 
     const body = await res.json();

--- a/tests/api/observability-maintenance.test.ts
+++ b/tests/api/observability-maintenance.test.ts
@@ -38,7 +38,7 @@ describe("GET /observability/stats/orphaned-pending", () => {
   it("returns orphaned_pending count", async ({ skip }) => {
     if (!doltAvailable) skip();
 
-    const res = await app.request("/observability/stats/orphaned-pending");
+    const res = await app.request("/v1/observability/stats/orphaned-pending");
     expect(res.status).toBe(200);
 
     const body = await res.json();
@@ -49,7 +49,7 @@ describe("GET /observability/stats/orphaned-pending", () => {
   it("accepts max_age_hours parameter", async ({ skip }) => {
     if (!doltAvailable) skip();
 
-    const res = await app.request("/observability/stats/orphaned-pending?max_age_hours=48");
+    const res = await app.request("/v1/observability/stats/orphaned-pending?max_age_hours=48");
     expect(res.status).toBe(200);
 
     const body = await res.json();
@@ -61,7 +61,7 @@ describe("POST /observability/maintenance/cleanup-pending", () => {
   it("returns deleted count with committed null when nothing deleted", async ({ skip }) => {
     if (!doltAvailable) skip();
 
-    const res = await app.request("/observability/maintenance/cleanup-pending", {
+    const res = await app.request("/v1/observability/maintenance/cleanup-pending", {
       method: "POST",
     });
     expect(res.status).toBe(200);
@@ -80,7 +80,7 @@ describe("POST /observability/maintenance/cleanup-pending", () => {
   it("accepts max_age_hours parameter", async ({ skip }) => {
     if (!doltAvailable) skip();
 
-    const res = await app.request("/observability/maintenance/cleanup-pending?max_age_hours=48", {
+    const res = await app.request("/v1/observability/maintenance/cleanup-pending?max_age_hours=48", {
       method: "POST",
     });
     expect(res.status).toBe(200);
@@ -95,7 +95,7 @@ describe("POST /observability/maintenance/cleanup-pending", () => {
     const originalKey = process.env.HAOL_API_KEY;
     process.env.HAOL_API_KEY = "test-secret-key";
     try {
-      const res = await app.request("/observability/maintenance/cleanup-pending", {
+      const res = await app.request("/v1/observability/maintenance/cleanup-pending", {
         method: "POST",
       });
       expect(res.status).toBe(401);
@@ -114,7 +114,7 @@ describe("POST /observability/maintenance/cleanup-pending", () => {
     const originalKey = process.env.HAOL_API_KEY;
     process.env.HAOL_API_KEY = "test-secret-key";
     try {
-      const res = await app.request("/observability/maintenance/cleanup-pending", {
+      const res = await app.request("/v1/observability/maintenance/cleanup-pending", {
         method: "POST",
         headers: { Authorization: "Bearer test-secret-key" },
       });

--- a/tests/api/outcomes.test.ts
+++ b/tests/api/outcomes.test.ts
@@ -48,7 +48,7 @@ describe("POST /tasks/:id/outcome", () => {
   it("records downstream outcome → 201", async ({ skip }) => {
     if (!doltAvailable) skip();
 
-    const res = await app.request("/tasks/" + testTaskId + "/outcome", {
+    const res = await app.request("/v1/tasks/" + testTaskId + "/outcome", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
@@ -67,7 +67,7 @@ describe("POST /tasks/:id/outcome", () => {
   it("rejects invalid body → 400", async ({ skip }) => {
     if (!doltAvailable) skip();
 
-    const res = await app.request("/tasks/" + testTaskId + "/outcome", {
+    const res = await app.request("/v1/tasks/" + testTaskId + "/outcome", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({}),
@@ -82,7 +82,7 @@ describe("GET /tasks/:id/outcomes", () => {
     if (!doltAvailable) skip();
 
     // First post an outcome to ensure at least one exists
-    await app.request("/tasks/" + testTaskId + "/outcome", {
+    await app.request("/v1/tasks/" + testTaskId + "/outcome", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
@@ -92,7 +92,7 @@ describe("GET /tasks/:id/outcomes", () => {
       }),
     });
 
-    const res = await app.request("/tasks/" + testTaskId + "/outcomes");
+    const res = await app.request("/v1/tasks/" + testTaskId + "/outcomes");
     expect(res.status).toBe(200);
 
     const body = await res.json();
@@ -103,7 +103,7 @@ describe("GET /tasks/:id/outcomes", () => {
   it("filters by tier", async ({ skip }) => {
     if (!doltAvailable) skip();
 
-    const res = await app.request("/tasks/" + testTaskId + "/outcomes?tier=3");
+    const res = await app.request("/v1/tasks/" + testTaskId + "/outcomes?tier=3");
     expect(res.status).toBe(200);
 
     const body = await res.json();
@@ -116,7 +116,7 @@ describe("GET /tasks/:id/outcomes", () => {
   it("returns empty array for valid task with no outcomes", async ({ skip }) => {
     if (!doltAvailable) skip();
 
-    const res = await app.request("/tasks/" + emptyTaskId + "/outcomes");
+    const res = await app.request("/v1/tasks/" + emptyTaskId + "/outcomes");
     expect(res.status).toBe(200);
 
     const body = await res.json();
@@ -127,7 +127,7 @@ describe("GET /tasks/:id/outcomes", () => {
   it("returns 404 for non-existent task", async ({ skip }) => {
     if (!doltAvailable) skip();
 
-    const res = await app.request("/tasks/nonexistent-task-no-outcomes/outcomes");
+    const res = await app.request("/v1/tasks/nonexistent-task-no-outcomes/outcomes");
     expect(res.status).toBe(404);
 
     const body = await res.json();
@@ -139,7 +139,7 @@ describe("GET /tasks/:id/outcomes/summary", () => {
   it("returns aggregated summary", async ({ skip }) => {
     if (!doltAvailable) skip();
 
-    const res = await app.request("/tasks/" + testTaskId + "/outcomes/summary");
+    const res = await app.request("/v1/tasks/" + testTaskId + "/outcomes/summary");
     expect(res.status).toBe(200);
 
     const body = await res.json();
@@ -153,7 +153,7 @@ describe("GET /tasks/:id/outcomes/summary", () => {
   it("returns empty summary for valid task with no outcomes", async ({ skip }) => {
     if (!doltAvailable) skip();
 
-    const res = await app.request("/tasks/" + emptyTaskId + "/outcomes/summary");
+    const res = await app.request("/v1/tasks/" + emptyTaskId + "/outcomes/summary");
     expect(res.status).toBe(200);
 
     const body = await res.json();
@@ -164,7 +164,7 @@ describe("GET /tasks/:id/outcomes/summary", () => {
   it("returns 404 for non-existent task", async ({ skip }) => {
     if (!doltAvailable) skip();
 
-    const res = await app.request("/tasks/nonexistent-task-no-summary/outcomes/summary");
+    const res = await app.request("/v1/tasks/nonexistent-task-no-summary/outcomes/summary");
     expect(res.status).toBe(404);
 
     const body = await res.json();

--- a/tests/api/tasks.test.ts
+++ b/tests/api/tasks.test.ts
@@ -59,7 +59,7 @@ async function pollUntilDone(
   let lastBody: Record<string, unknown> = {};
   let lastStatus = 0;
   while (Date.now() < deadline) {
-    const res = await app.request(`/tasks/${taskId}`);
+    const res = await app.request(`/v1/tasks/${taskId}`);
     lastStatus = res.status;
     lastBody = (await res.json()) as Record<string, unknown>;
     if (lastBody.done === true) {
@@ -150,20 +150,20 @@ describe("POST /tasks", () => {
     if (!doltAvailable) skip();
     mockFetchSuccess("Summary result");
 
-    const res = await app.request("/tasks", {
+    const res = await app.request("/v1/tasks", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ prompt: `${TEST_PROMPT_PREFIX}summarize text about testing` }),
     });
 
     expect(res.status).toBe(202);
-    expect(res.headers.get("Location")).toMatch(/^\/tasks\/.+/);
+    expect(res.headers.get("Location")).toMatch(/^\/v1\/tasks\/.+/);
     expect(res.headers.get("Retry-After")).toBe("1");
 
     const body = await res.json();
     expect(body.task_id).toBeTruthy();
     expect(body.status).toBe("QUEUED");
-    expect(body.links?.self).toBe(`/tasks/${body.task_id}`);
+    expect(body.links?.self).toBe(`/v1/tasks/${body.task_id}`);
 
     // Worker drains the queue and the task reaches COMPLETED.
     const polled = await pollUntilDone(body.task_id);
@@ -174,7 +174,7 @@ describe("POST /tasks", () => {
   it("rejects empty prompt → 400", async ({ skip }) => {
     if (!doltAvailable) skip();
 
-    const res = await app.request("/tasks", {
+    const res = await app.request("/v1/tasks", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ prompt: "" }),
@@ -189,7 +189,7 @@ describe("GET /tasks/:id", () => {
     if (!doltAvailable) skip();
     mockFetchSuccess("Done.");
 
-    const createRes = await app.request("/tasks", {
+    const createRes = await app.request("/v1/tasks", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ prompt: `${TEST_PROMPT_PREFIX}classify this review` }),
@@ -208,7 +208,7 @@ describe("GET /tasks/:id", () => {
   it("returns 404 for non-existent task", async ({ skip }) => {
     if (!doltAvailable) skip();
 
-    const res = await app.request("/tasks/non-existent-task-id");
+    const res = await app.request("/v1/tasks/non-existent-task-id");
     expect(res.status).toBe(404);
   });
 });
@@ -218,7 +218,7 @@ describe("GET /tasks/:id/trace", () => {
     if (!doltAvailable) skip();
     mockFetchSuccess("Trace test result");
 
-    const createRes = await app.request("/tasks", {
+    const createRes = await app.request("/v1/tasks", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
@@ -291,7 +291,7 @@ describe("GET /tasks/:id/trace", () => {
       ],
     );
 
-    const res = await app.request(`/tasks/${created.task_id}/trace`);
+    const res = await app.request(`/v1/tasks/${created.task_id}/trace`);
     expect(res.status).toBe(200);
 
     const trace = await res.json();
@@ -317,7 +317,7 @@ describe("GET /tasks/:id/trace", () => {
   it("returns 404 for non-existent task", async ({ skip }) => {
     if (!doltAvailable) skip();
 
-    const res = await app.request("/tasks/non-existent-id/trace");
+    const res = await app.request("/v1/tasks/non-existent-id/trace");
     expect(res.status).toBe(404);
   });
 });

--- a/tests/cli/status.test.ts
+++ b/tests/cli/status.test.ts
@@ -107,7 +107,7 @@ describe("status command", () => {
     });
 
     const call = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
-    expect(call[0]).toBe("http://localhost:3000/tasks/abc-123");
+    expect(call[0]).toBe("http://localhost:3000/v1/tasks/abc-123");
   });
 });
 


### PR DESCRIPTION
## Summary

- Mount existing routes (`tasks`, `agents`, `outcomes`, `observability`) under `/v1` so 1.0 can publish a stable, versioned contract. `/` stays reserved for cross-version concerns (`/health` today, `/v2` later).
- Auth + rate-limit middleware paths, the `POST /tasks` `Location` header and `links.self` body field, every CLI fetch, the load-test script, the integration tests, and the README curl examples all moved to `/v1/...`.
- `/health` stays unversioned. The demo UI's internal `/demo/api/*` proxy is also unchanged — it's not part of the public contract.

## Test plan

- [x] `npm run build` clean
- [x] `npm test` — 91 unit tests pass without Dolt; 407 pass with Dolt running. The 19 remaining failures (rate-limit 429s in the tasks polling loop, worker timeouts, router/tier-timeouts integration flakes, one cascade off-by-one) reproduce on a clean `main`, so none are introduced by this change
- [ ] Spot-check `curl http://localhost:3000/v1/tasks ...` and `curl http://localhost:3000/health` against a running server before merging