### PR TITLE
Gate demo routes behind HAOL_ENABLE_DEMO and patch moderate CVEs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,3 +45,12 @@ MEMORY_STEP_TIMEOUT_MS=5000
 # steps short-circuit to no-ops without waiting. Caps the worst-case memory
 # tail latency a single task can incur. Minimum 100ms; default 8000.
 MEMORY_TASK_BUDGET_MS=8000
+
+# Demo UI gate. When set to "1", mounts the unauthenticated /demo/* routes
+# (static UI + POST /demo/api/task + GET /demo/api/savings). The demo
+# endpoint routes anonymous traffic to paid LLM providers — only enable
+# for live demos or local development. Default: unset (demo not mounted).
+# Note: max_tokens and timeout_ms on demo requests are server-side clamped
+# to T1-equivalent caps regardless of caller-supplied values, and the
+# write endpoint uses a global 5/min rate limit.
+# HAOL_ENABLE_DEMO=1

--- a/package-lock.json
+++ b/package-lock.json
@@ -474,9 +474,9 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.10",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.10.tgz",
-      "integrity": "sha512-hZ7nOssGqRgyV3FVVQdfi+U4q02uB23bpnYpdvNXkYTRRyWx84b7yf1ans+dnJ/7h41sGL3CeQTfO+ZGxuO+Iw==",
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
       "license": "MIT",
       "engines": {
         "node": ">=18.14.1"
@@ -1205,9 +1205,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.7",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.7.tgz",
-      "integrity": "sha512-jq9l1DM0zVIvsm3lv9Nw9nlJnMNPOcAtsbsgiUhWcFzPE99Gvo6yRTlszSLLYacMeQ6quHD6hMfId8crVHvexw==",
+      "version": "4.12.18",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
+      "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -1404,9 +1404,9 @@
       "license": "MIT"
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "demo:setup": "tsx scripts/demo-setup.ts",
     "load-test": "tsx scripts/load-test.ts",
     "format": "prettier --write .",
-    "format:check": "prettier --check ."
+    "format:check": "prettier --check .",
+    "audit": "npm audit --audit-level=moderate --omit=dev"
   },
   "engines": {
     "node": ">=20.0.0"

--- a/src/api/app.ts
+++ b/src/api/app.ts
@@ -44,7 +44,11 @@ export function createApp(): Hono {
   // across rotating addresses. 5/min globally bounds worst-case LLM spend.
   if (process.env.HAOL_ENABLE_DEMO === "1") {
     const demoWriteLimit = rateLimit({ limit: 5, windowMs: 60_000, global: true });
-    app.use(
+    // serveStatic is bound to GET only. app.use("/demo/*", ...) would run
+    // the static handler on POST as well — a POST /demo/api/task with a
+    // matching ./public/api/task file would be served statically and never
+    // reach the rate limiter, defeating the spend cap.
+    app.get(
       "/demo/*",
       serveStatic({ root: "./public/", rewriteRequestPath: (p) => p.replace(/^\/demo/, "") }),
     );

--- a/src/api/app.ts
+++ b/src/api/app.ts
@@ -34,12 +34,24 @@ export function createApp(): Hono {
   // Middleware
   app.use("*", requestId);
 
-  // Demo UI — static files and API proxy, unauthenticated
-  app.use(
-    "/demo/*",
-    serveStatic({ root: "./public/", rewriteRequestPath: (p) => p.replace(/^\/demo/, "") }),
-  );
-  app.route("/", demo);
+  // Demo UI is opt-in. It exposes an unauthenticated path to the router
+  // (paid LLM calls) and is intended for live demos / local dev only.
+  // Production deployments must explicitly set HAOL_ENABLE_DEMO=1.
+  //
+  // Demo write bucket is allocated per-app so multiple app instances (tests,
+  // hot reload) don't share state. Tight, process-wide (global: true): the
+  // route is unauthenticated, so per-IP would let an attacker spread spend
+  // across rotating addresses. 5/min globally bounds worst-case LLM spend.
+  if (process.env.HAOL_ENABLE_DEMO === "1") {
+    const demoWriteLimit = rateLimit({ limit: 5, windowMs: 60_000, global: true });
+    app.use(
+      "/demo/*",
+      serveStatic({ root: "./public/", rewriteRequestPath: (p) => p.replace(/^\/demo/, "") }),
+    );
+    app.post("/demo/api/task", demoWriteLimit);
+    app.get("/demo/api/savings", readLimit);
+    app.route("/", demo);
+  }
 
   // Health check is unversioned (load balancers, K8s probes) and unauthenticated.
   // Reserved unversioned root for cross-version concerns (health, future

--- a/src/api/routes/demo.ts
+++ b/src/api/routes/demo.ts
@@ -5,6 +5,12 @@ import { costSavings } from "../../observability/queries.js";
 
 const demo = new Hono();
 
+// Anonymous-callable demo caps. Tightly bounds worst-case spend per request:
+// caller-supplied constraints are clamped down (never expanded) so a public
+// demo can't request 4M-token completions or hours-long timeouts.
+const DEMO_MAX_TOKENS = 1024;
+const DEMO_TIMEOUT_MS = 15_000;
+
 demo.post("/demo/api/task", async (c) => {
   const body = await c.req.json();
   const parsed = RouterTaskInput.safeParse(body);
@@ -12,7 +18,17 @@ demo.post("/demo/api/task", async (c) => {
     return c.json({ error: parsed.error.message }, 400);
   }
 
-  const result = await routeTask(parsed.data);
+  const input = parsed.data;
+  const clamped: RouterTaskInput = {
+    ...input,
+    constraints: {
+      ...input.constraints,
+      max_tokens: Math.min(input.constraints?.max_tokens ?? DEMO_MAX_TOKENS, DEMO_MAX_TOKENS),
+      timeout_ms: Math.min(input.constraints?.timeout_ms ?? DEMO_TIMEOUT_MS, DEMO_TIMEOUT_MS),
+    },
+  };
+
+  const result = await routeTask(clamped);
   return c.json(result, result.status === "FAILED" ? 500 : 201);
 });
 

--- a/src/api/routes/demo.ts
+++ b/src/api/routes/demo.ts
@@ -6,8 +6,10 @@ import { costSavings } from "../../observability/queries.js";
 const demo = new Hono();
 
 // Anonymous-callable demo caps. Tightly bounds worst-case spend per request:
-// caller-supplied constraints are clamped down (never expanded) so a public
-// demo can't request 4M-token completions or hours-long timeouts.
+// prompt is truncated (input tokens are billed even when output is clamped),
+// and caller-supplied constraints are clamped down (never expanded) so a
+// public demo can't request 4M-token completions or hours-long timeouts.
+const DEMO_MAX_PROMPT_CHARS = 4_000; // ~1k input tokens at ~4 chars/token
 const DEMO_MAX_TOKENS = 1024;
 const DEMO_TIMEOUT_MS = 15_000;
 
@@ -21,6 +23,7 @@ demo.post("/demo/api/task", async (c) => {
   const input = parsed.data;
   const clamped: RouterTaskInput = {
     ...input,
+    prompt: input.prompt.slice(0, DEMO_MAX_PROMPT_CHARS),
     constraints: {
       ...input.constraints,
       max_tokens: Math.min(input.constraints?.max_tokens ?? DEMO_MAX_TOKENS, DEMO_MAX_TOKENS),

--- a/tests/api/demo.test.ts
+++ b/tests/api/demo.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+// Stub routeTask before importing createApp so the demo route never reaches
+// the real router (no DB / LLM dependencies needed for this test file).
+const routeTaskMock = vi.fn();
+vi.mock("../../src/router/router.js", () => ({
+  routeTask: (...args: unknown[]) => routeTaskMock(...args),
+}));
+
+// costSavings is also imported by demo.ts; stub it so the GET handler
+// doesn't try to query Dolt.
+vi.mock("../../src/observability/queries.js", async (importOriginal) => {
+  const original = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...original,
+    costSavings: vi.fn().mockResolvedValue({ savings_usd: 0, baseline_usd: 0 }),
+  };
+});
+
+import { createApp } from "../../src/api/app.js";
+
+const ORIGINAL_FLAG = process.env.HAOL_ENABLE_DEMO;
+
+function buildSuccessfulRouterResponse() {
+  routeTaskMock.mockResolvedValue({
+    task_id: "01J0TEST",
+    status: "COMPLETED",
+    complexity_tier: 1,
+    selected_agent_id: "agent-x",
+    response_content: "ok",
+    cost_usd: 0.001,
+    latency_ms: 42,
+    error: null,
+  });
+}
+
+describe("/demo gating", () => {
+  beforeEach(() => {
+    routeTaskMock.mockReset();
+  });
+
+  afterEach(() => {
+    if (ORIGINAL_FLAG === undefined) {
+      delete process.env.HAOL_ENABLE_DEMO;
+    } else {
+      process.env.HAOL_ENABLE_DEMO = ORIGINAL_FLAG;
+    }
+  });
+
+  it("returns 404 for /demo/api/task when HAOL_ENABLE_DEMO is unset", async () => {
+    delete process.env.HAOL_ENABLE_DEMO;
+    const app = createApp();
+
+    const res = await app.request("/demo/api/task", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ prompt: "hello" }),
+    });
+
+    expect(res.status).toBe(404);
+    expect(routeTaskMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 for /demo/api/savings when HAOL_ENABLE_DEMO is unset", async () => {
+    delete process.env.HAOL_ENABLE_DEMO;
+    const app = createApp();
+
+    const res = await app.request("/demo/api/savings");
+    expect(res.status).toBe(404);
+  });
+
+  it("rate-limits POST /demo/api/task to 5 requests per minute (global bucket)", async () => {
+    process.env.HAOL_ENABLE_DEMO = "1";
+    buildSuccessfulRouterResponse();
+    const app = createApp();
+
+    const send = () =>
+      app.request("/demo/api/task", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ prompt: "hello" }),
+      });
+
+    // 5 successes
+    for (let i = 0; i < 5; i++) {
+      const res = await send();
+      expect(res.status).toBe(201);
+    }
+
+    // 6th rejected with 429, regardless of source IP (global bucket)
+    const blocked = await send();
+    expect(blocked.status).toBe(429);
+    expect(blocked.headers.get("Retry-After")).toBeTruthy();
+  });
+
+  it("clamps caller-supplied max_tokens and timeout_ms before invoking routeTask", async () => {
+    process.env.HAOL_ENABLE_DEMO = "1";
+    buildSuccessfulRouterResponse();
+    const app = createApp();
+
+    const res = await app.request("/demo/api/task", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        prompt: "hello",
+        constraints: { max_tokens: 100_000, timeout_ms: 600_000, temperature: 0.5 },
+      }),
+    });
+
+    expect(res.status).toBe(201);
+    expect(routeTaskMock).toHaveBeenCalledTimes(1);
+    const passedInput = routeTaskMock.mock.calls[0][0] as {
+      constraints: { max_tokens: number; timeout_ms: number; temperature: number };
+    };
+    expect(passedInput.constraints.max_tokens).toBe(1024);
+    expect(passedInput.constraints.timeout_ms).toBe(15_000);
+    // Non-clamped fields pass through untouched.
+    expect(passedInput.constraints.temperature).toBe(0.5);
+  });
+
+  it("applies the clamps even when caller omits constraints entirely", async () => {
+    process.env.HAOL_ENABLE_DEMO = "1";
+    buildSuccessfulRouterResponse();
+    const app = createApp();
+
+    const res = await app.request("/demo/api/task", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ prompt: "hello" }),
+    });
+
+    expect(res.status).toBe(201);
+    const passedInput = routeTaskMock.mock.calls[0][0] as {
+      constraints: { max_tokens: number; timeout_ms: number };
+    };
+    expect(passedInput.constraints.max_tokens).toBe(1024);
+    expect(passedInput.constraints.timeout_ms).toBe(15_000);
+  });
+});

--- a/tests/api/demo.test.ts
+++ b/tests/api/demo.test.ts
@@ -136,4 +136,59 @@ describe("/demo gating", () => {
     expect(passedInput.constraints.max_tokens).toBe(1024);
     expect(passedInput.constraints.timeout_ms).toBe(15_000);
   });
+
+  it("truncates oversized prompts to bound input-token spend", async () => {
+    process.env.HAOL_ENABLE_DEMO = "1";
+    buildSuccessfulRouterResponse();
+    const app = createApp();
+
+    // Zod's RouterTaskInput allows up to 100k chars; demo clamps to 4k.
+    const oversized = "a".repeat(50_000);
+    const res = await app.request("/demo/api/task", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ prompt: oversized }),
+    });
+
+    expect(res.status).toBe(201);
+    const passedInput = routeTaskMock.mock.calls[0][0] as { prompt: string };
+    expect(passedInput.prompt.length).toBe(4_000);
+  });
+
+  it("leaves prompts within the cap unchanged", async () => {
+    process.env.HAOL_ENABLE_DEMO = "1";
+    buildSuccessfulRouterResponse();
+    const app = createApp();
+
+    const original = "short prompt";
+    const res = await app.request("/demo/api/task", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ prompt: original }),
+    });
+
+    expect(res.status).toBe(201);
+    const passedInput = routeTaskMock.mock.calls[0][0] as { prompt: string };
+    expect(passedInput.prompt).toBe(original);
+  });
+
+  it("does not let serveStatic intercept POST /demo/api/task", async () => {
+    // Regression: if /demo/* were mounted with app.use() rather than
+    // app.get(), serveStatic would run on POST and could serve a matching
+    // file from ./public/, bypassing the rate limiter and the handler.
+    // We can't create files inside ./public/ from a test, but we can verify
+    // the POST reaches our handler by asserting routeTask was invoked.
+    process.env.HAOL_ENABLE_DEMO = "1";
+    buildSuccessfulRouterResponse();
+    const app = createApp();
+
+    const res = await app.request("/demo/api/task", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ prompt: "hi" }),
+    });
+
+    expect(res.status).toBe(201);
+    expect(routeTaskMock).toHaveBeenCalledTimes(1);
+  });
 });


### PR DESCRIPTION
## Summary

Closes audit findings **#1** (`/demo/*` bypassing auth + rate limit) and **#3** (7 moderate CVEs in deps) from `code-audit.md`.

- **Demo gate.** `/demo/*` no longer mounts unless `HAOL_ENABLE_DEMO=1` is set explicitly. Default off everywhere — including production. Previously anonymous callers could POST prompts to `routeTask()` and burn paid LLM budget.
- **Demo rate limit.** `POST /demo/api/task` is now bound by a global 5/min bucket (allocated per-app instance). Per-IP would let an attacker spread spend across rotating addresses.
- **Demo input clamps.** `max_tokens` and `timeout_ms` are clamped server-side to 1024 / 15s. Caller-supplied values can only shrink the bounds, never expand them.
- **Dependency upgrades.** `npm audit fix` (non-breaking): `hono` 4.12.7→4.12.18, `@hono/node-server` 1.19.10→1.19.14, `postcss` 8.5.8→8.5.14. Production deps now report 0 vulnerabilities. The Hono `serveStatic` slash-bypass (GHSA-wmmm-f939-6g9c) is the same code path used at the demo mount, so this lands together with the demo gate.
- **Audit script.** New `npm run audit` runs `npm audit --audit-level=moderate --omit=dev` for CI. Remaining 4 vulns are dev-only vite chains that need vitest v4 (breaking) — left for follow-up.

## Test plan

- [x] `npm run build` clean
- [x] `npm run audit` reports 0 vulnerabilities (production deps)
- [x] New `tests/api/demo.test.ts` covers:
  - 404 on `/demo/api/task` and `/demo/api/savings` when flag unset
  - 429 after 5 calls when flag enabled (global bucket)
  - `max_tokens` clamped to 1024 even when caller requests 100,000
  - `timeout_ms` clamped to 15s even when caller requests 600,000
  - Clamps applied when caller omits `constraints` entirely
- [x] Middleware tests still pass (api-key-auth, rate-limit, error-handler, request-id, demo, health)
- [ ] Manually verify in a deploy: confirm `/demo/api/task` returns 404 when `HAOL_ENABLE_DEMO` is unset

Pre-existing flaky failures in `tests/api/tasks.test.ts` reproduce on `main` and are unrelated to this change.