### PR TITLE
Reaper: age stale tasks from worker_started_at, not created_at

### DIFF
--- a/src/repositories/task-log.ts
+++ b/src/repositories/task-log.ts
@@ -238,6 +238,12 @@ interface StaleTaskRow extends RowDataPacket {
  * states longer than maxAgeSeconds. QUEUED is excluded — it's handled
  * separately by findQueued() since it's safe to retry.
  *
+ * Age is measured from worker pickup (`worker_started_at`), not intake
+ * (`created_at`). A row that sat in QUEUED for an hour before a worker
+ * claimed it is healthy work, not a crashed worker. COALESCE falls back
+ * to created_at for any row that predates migration 019 or somehow
+ * reached an in-flight state without claimQueued() stamping the column.
+ *
  * Returns only task_ids — the reaper does not need prompt/metadata/etc.
  * for these rows (it just marks them FAILED + deletes the session branch),
  * and SELECT * would pull the LONGTEXT prompt for every stale row.
@@ -246,8 +252,8 @@ export async function findStale(maxAgeSeconds: number): Promise<string[]> {
   const rows = await query<StaleTaskRow[]>(
     `SELECT task_id FROM task_log
        WHERE status IN ('RECEIVED','CLASSIFIED','DISPATCHED')
-         AND created_at < (NOW() - INTERVAL ? SECOND)
-       ORDER BY created_at ASC`,
+         AND COALESCE(worker_started_at, created_at) < (NOW() - INTERVAL ? SECOND)
+       ORDER BY COALESCE(worker_started_at, created_at) ASC`,
     [maxAgeSeconds],
   );
   return rows.map((r) => r.task_id);

--- a/tests/services/task-worker.test.ts
+++ b/tests/services/task-worker.test.ts
@@ -228,6 +228,38 @@ describe("task-reaper", () => {
     expect(row?.worker_error).toBe("worker_crashed");
   });
 
+  it("does not reap rows whose worker_started_at is recent, even with old created_at", async ({
+    skip,
+  }) => {
+    if (!doltAvailable) skip();
+
+    // Regression: previously findStale filtered on created_at, which is set
+    // at intake. A task that sat in QUEUED for hours before a worker claimed
+    // it would be killed seconds after pickup. The fix moves the age check
+    // to worker_started_at (falling back to created_at for legacy rows).
+
+    const taskId = uuidv7();
+    const prompt = `${TEST_PROMPT_PREFIX}reaper respects worker_started_at`;
+    await taskLog.createQueued(taskId, sha256(prompt), { prompt });
+
+    const pool = getPool();
+    await pool.query(
+      `UPDATE task_log
+         SET status = 'DISPATCHED',
+             selected_agent_id = 'wrk-test-haiku',
+             created_at = NOW() - INTERVAL 1 DAY,
+             worker_started_at = NOW() - INTERVAL 5 SECOND
+       WHERE task_id = ?`,
+      [taskId],
+    );
+
+    await runReaperOnce();
+
+    const row = await taskLog.findById(taskId);
+    expect(row?.status).toBe("DISPATCHED");
+    expect(row?.worker_error).toBeNull();
+  });
+
   it("preserves session branch when reaping a stale row", async ({ skip }) => {
     if (!doltAvailable) skip();
 


### PR DESCRIPTION
## Summary

Closes audit finding **#2** from `code-audit.md` — the reaper was killing legitimately in-flight tasks under any queue backlog.

`findStale` (src/repositories/task-log.ts:245-253) filtered on `created_at`, which is set at intake (QUEUED). A task that sat in the queue 9 minutes before pickup got marked `worker_crashed` ~30 seconds after the worker actually claimed it.

Switch the age check to `COALESCE(worker_started_at, created_at)`. The `worker_started_at` column already exists from migration 019 and is stamped by `claimQueued` on the QUEUED→RECEIVED transition (src/repositories/task-log.ts:178-188). `COALESCE` falls back to `created_at` for any row that predates the column or somehow reached an in-flight state without `claimQueued` having run.

No migration needed — column already exists. The existing `idx_task_log_status_created` covers the `status IN (...)` predicate; the in-flight set is small (bounded by `WORKER_CONCURRENCY × in-flight-seconds`) so the COALESCE residual filter is cheap.

## Test plan

- [x] New regression test `does not reap rows whose worker_started_at is recent, even with old created_at` — passes (verified locally against running Dolt). Sets `created_at = 1 day ago` and `worker_started_at = 5 seconds ago`, runs the reaper, asserts the row stays in DISPATCHED with no `worker_error`.
- [x] Existing test `marks stale DISPATCHED rows FAILED with worker_crashed` still passes — proves COALESCE fallback still reaps legitimately-stale rows where `worker_started_at` is null.
- [x] Existing test `preserves session branch when reaping a stale row` still passes.
- [x] `npm run build` clean.
- [x] `npm run audit` reports 0 production vulnerabilities.

Pre-existing flaky `pollUntilDone` timeouts in `tests/services/task-worker.test.ts` reproduce on `main` and are unrelated to this change.