### PR TITLE
Memory: serialize main-branch merges and stage memory tables only

### DIFF
--- a/src/db/dolt.ts
+++ b/src/db/dolt.ts
@@ -109,6 +109,23 @@ export async function doltActiveBranch(conn?: Queryable): Promise<string> {
 }
 
 /**
+ * True when an error from DOLT_COMMIT indicates the staged set was empty.
+ *
+ * Dolt currently surfaces this as "nothing to commit" (mirroring git), but
+ * "nothing staged" / "nothing added" appear in adjacent Dolt error paths
+ * and could plausibly replace the canonical phrasing in a future release.
+ * This predicate matches all three forms so a Dolt upgrade doesn't silently
+ * convert a no-op into a hard failure on best-effort commit paths. If Dolt
+ * adds a stable error code for this condition, prefer matching the code.
+ *
+ * Tested against Dolt 1.43+. Re-verify on major version bumps.
+ */
+export function isNothingToCommitError(err: unknown): boolean {
+  const msg = (err as Error | undefined)?.message ?? "";
+  return /nothing (to commit|staged|added)/i.test(msg);
+}
+
+/**
  * Best-effort Dolt commit on a dedicated connection.
  * Acquires its own connection from the pool so the commit targets the
  * correct (main) branch regardless of pool connection state.
@@ -123,7 +140,7 @@ export async function commitSafely(
     try {
       await doltCommit({ message, author, allowEmpty }, conn);
     } catch (err) {
-      if (!(err as Error).message?.includes("nothing to commit")) {
+      if (!isNothingToCommitError(err)) {
         throw err;
       }
     }

--- a/src/db/dolt.ts
+++ b/src/db/dolt.ts
@@ -4,6 +4,20 @@ export interface DoltCommitOptions {
   message: string;
   author?: string;
   allowEmpty?: boolean;
+  /**
+   * Restrict the commit to a specific set of tables. When provided, the helper
+   * stages exactly those tables (via DOLT_ADD) before committing — residue
+   * from other tables in the working set is left untouched. When omitted,
+   * the commit auto-stages all changes (-A), which is the right default for
+   * most callers but corrupts attribution when the working set is shared
+   * across pool connections (see commitSession in src/memory/session-manager.ts).
+   *
+   * Table names are passed as procedure args (string literals to DOLT_ADD),
+   * not identifiers, so they are not vulnerable to SQL injection — but they
+   * are interpreted as table names by Dolt, so callers must provide trusted
+   * names from a fixed allow-list.
+   */
+  tables?: string[];
 }
 
 export async function doltCommit(opts: DoltCommitOptions, conn?: Queryable): Promise<string> {
@@ -16,7 +30,19 @@ export async function doltCommit(opts: DoltCommitOptions, conn?: Queryable): Pro
     args.push("--allow-empty");
   }
 
-  // DOLT_COMMIT with -A flag to auto-stage all changes
+  if (opts.tables && opts.tables.length > 0) {
+    // Stage only the specified tables, then commit without -A so residue
+    // from other tables in the shared working set isn't authored under this
+    // commit. DOLT_ADD takes table names as positional args.
+    const addPlaceholders = opts.tables.map(() => "?").join(", ");
+    await db.query(`CALL DOLT_ADD(${addPlaceholders})`, opts.tables);
+    const placeholders = args.map(() => "?").join(", ");
+    const [rows] = await db.query(`CALL DOLT_COMMIT(${placeholders})`, args);
+    const result = rows as Record<string, string>[];
+    return result[0]?.hash ?? "";
+  }
+
+  // Default: DOLT_COMMIT with -A flag to auto-stage all changes
   const placeholders = args.map(() => "?").join(", ");
   const [rows] = await db.query(`CALL DOLT_COMMIT('-A', ${placeholders})`, args);
   const result = rows as Record<string, string>[];

--- a/src/db/migrate.ts
+++ b/src/db/migrate.ts
@@ -4,7 +4,7 @@ import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { loadConfig } from "../config.js";
 import { createPool, getPool, destroy } from "./connection.js";
-import { doltCommit } from "./dolt.js";
+import { doltCommit, isNothingToCommitError } from "./dolt.js";
 
 const __dirname = fileURLToPath(new URL(".", import.meta.url));
 const MIGRATIONS_DIR = join(__dirname, "migrations");
@@ -158,7 +158,7 @@ async function main() {
     });
     console.log("Dolt commit created.");
   } catch (err) {
-    if ((err as Error).message?.includes("nothing to commit")) {
+    if (isNothingToCommitError(err)) {
       console.log("No changes to commit (already up to date).");
     } else {
       throw err;

--- a/src/memory/session-manager.ts
+++ b/src/memory/session-manager.ts
@@ -7,9 +7,11 @@ import {
   doltMerge,
   doltDeleteBranch,
   doltActiveBranch,
+  isNothingToCommitError,
 } from "../db/dolt.js";
 import * as sessionRepo from "../repositories/session-context.js";
 import * as handoffRepo from "../repositories/handoff-summary.js";
+import { logger } from "../logging/logger.js";
 
 // Tables that the memory layer is authoritative for. The pre-merge flush in
 // commitSession stages only these so attribution can never accidentally
@@ -41,7 +43,17 @@ async function withMainMergeLock<T>(conn: PoolConnection, fn: () => Promise<T>):
   ]);
   const acquired = rows[0]?.acquired;
   if (acquired !== 1) {
-    // 0 = timeout, NULL = error. Either way, leave main alone.
+    // 0 = timeout, NULL = error. Either way, leave main alone — but log at
+    // the failure site so contention is visible in structured logs without
+    // depending on the caller to wrap and re-log. Data on the session
+    // branch is not lost (branch-cleanup retains it) but it is not merged
+    // to main, which warrants visibility above debug.
+    logger.warn("could not acquire main merge lock", {
+      component: "memory",
+      lock_name: MAIN_MERGE_LOCK,
+      get_lock_result: acquired,
+      timeout_seconds: MAIN_MERGE_LOCK_TIMEOUT_SECONDS,
+    });
     return null;
   }
   try {
@@ -208,7 +220,7 @@ export async function commitSession(session: SessionHandle): Promise<void> {
           // tables outside MEMORY_TABLES (which we deliberately don't
           // stage) so the staged set may be empty. Real failures still
           // surface from the merge attempt below.
-          if (!(err as Error).message?.includes("nothing to commit")) {
+          if (!isNothingToCommitError(err)) {
             throw err;
           }
         }

--- a/src/memory/session-manager.ts
+++ b/src/memory/session-manager.ts
@@ -1,9 +1,4 @@
-import {
-  getPool,
-  withBranchConnection,
-  DEFAULT_BRANCH,
-  type Queryable,
-} from "../db/connection.js";
+import { getPool, withBranchConnection, DEFAULT_BRANCH, type Queryable } from "../db/connection.js";
 import type { PoolConnection, RowDataPacket } from "mysql2/promise";
 import {
   doltBranch,
@@ -39,14 +34,11 @@ interface LockRow extends RowDataPacket {
  * indicates something pathological is happening that warrants surfacing
  * upstream rather than blocking the task pipeline.
  */
-async function withMainMergeLock<T>(
-  conn: PoolConnection,
-  fn: () => Promise<T>,
-): Promise<T | null> {
-  const [rows] = await conn.query<LockRow[]>(
-    "SELECT GET_LOCK(?, ?) AS acquired",
-    [MAIN_MERGE_LOCK, MAIN_MERGE_LOCK_TIMEOUT_SECONDS],
-  );
+async function withMainMergeLock<T>(conn: PoolConnection, fn: () => Promise<T>): Promise<T | null> {
+  const [rows] = await conn.query<LockRow[]>("SELECT GET_LOCK(?, ?) AS acquired", [
+    MAIN_MERGE_LOCK,
+    MAIN_MERGE_LOCK_TIMEOUT_SECONDS,
+  ]);
   const acquired = rows[0]?.acquired;
   if (acquired !== 1) {
     // 0 = timeout, NULL = error. Either way, leave main alone.

--- a/src/memory/session-manager.ts
+++ b/src/memory/session-manager.ts
@@ -1,4 +1,10 @@
-import { getPool, withBranchConnection, DEFAULT_BRANCH, type Queryable } from "../db/connection.js";
+import {
+  getPool,
+  withBranchConnection,
+  DEFAULT_BRANCH,
+  type Queryable,
+} from "../db/connection.js";
+import type { PoolConnection, RowDataPacket } from "mysql2/promise";
 import {
   doltBranch,
   doltCheckout,
@@ -9,6 +15,55 @@ import {
 } from "../db/dolt.js";
 import * as sessionRepo from "../repositories/session-context.js";
 import * as handoffRepo from "../repositories/handoff-summary.js";
+
+// Tables that the memory layer is authoritative for. The pre-merge flush in
+// commitSession stages only these so attribution can never accidentally
+// capture residue from task_log/execution_log etc. left in the shared
+// working set on main by another connection.
+const MEMORY_TABLES = ["session_context", "handoff_summary"];
+
+// Advisory lock name for serializing main-branch operations across
+// concurrent commitSession calls. Connection-scoped, so it auto-releases
+// if the holding connection dies (process crash, network blip).
+const MAIN_MERGE_LOCK = "haol_merge_main";
+const MAIN_MERGE_LOCK_TIMEOUT_SECONDS = 5;
+
+interface LockRow extends RowDataPacket {
+  acquired: number | null;
+}
+
+/**
+ * Run `fn` while holding a connection-scoped advisory lock on main. Returns
+ * `null` if the lock can't be acquired in MAIN_MERGE_LOCK_TIMEOUT_SECONDS —
+ * memory work is best-effort, and waiting longer than that under contention
+ * indicates something pathological is happening that warrants surfacing
+ * upstream rather than blocking the task pipeline.
+ */
+async function withMainMergeLock<T>(
+  conn: PoolConnection,
+  fn: () => Promise<T>,
+): Promise<T | null> {
+  const [rows] = await conn.query<LockRow[]>(
+    "SELECT GET_LOCK(?, ?) AS acquired",
+    [MAIN_MERGE_LOCK, MAIN_MERGE_LOCK_TIMEOUT_SECONDS],
+  );
+  const acquired = rows[0]?.acquired;
+  if (acquired !== 1) {
+    // 0 = timeout, NULL = error. Either way, leave main alone.
+    return null;
+  }
+  try {
+    return await fn();
+  } finally {
+    try {
+      await conn.query("SELECT RELEASE_LOCK(?)", [MAIN_MERGE_LOCK]);
+    } catch {
+      // RELEASE_LOCK on a connection that's already lost the lock returns
+      // NULL — not an error we can act on. The lock auto-releases on
+      // connection close, so swallowing here is safe.
+    }
+  }
+}
 
 function parseJsonValue(val: unknown): unknown {
   if (typeof val === "string") {
@@ -127,54 +182,70 @@ export async function commitSession(session: SessionHandle): Promise<void> {
     // Dolt rolls them back on release, leaving the session branch behind.
     await conn.query("SET @@autocommit = 1");
     await ensureOnMain(conn);
-    // Pool connections under --no-auto-commit can carry an uncommitted
-    // working set on main from earlier writeContext callers (whose branch
-    // checkout leaks staged changes back onto main). DOLT_MERGE refuses to
-    // run with "local changes would be stomped by merge", so flush whatever
-    // is pending into a Dolt commit before merging. Gate on dolt_status so
-    // the common (clean working set) case doesn't add a noisy "pre-merge
-    // flush" entry to main's log on every successful task.
-    //
-    // Caveat: the working set on main is shared across connections within
-    // the branch, so residue this commit captures may be from a concurrent
-    // session — meaning the resulting commit on main may be authored under
-    // this task's id even if the residue isn't ours. We accept this rather
-    // than DOLT_RESET --hard, which would wipe legitimate not-yet-Dolt-
-    // committed writes from other connections (e.g. task_log inserts) and
-    // turn an attribution quirk into actual data loss.
-    const [statusRows] = await conn.query("SELECT 1 FROM dolt_status LIMIT 1");
-    if ((statusRows as unknown[]).length > 0) {
-      try {
+
+    // Serialize main-branch operations across concurrent tasks. The working
+    // set on main is shared across pool connections within the branch — two
+    // commitSession calls overlapping could otherwise have task X's flush
+    // capture task Y's staged changes, attributing them under X's identity
+    // and breaking the audit-trail guarantee. The lock ensures only one
+    // task at a time runs the flush+merge+branch-delete sequence on main.
+    const ran = await withMainMergeLock(conn, async () => {
+      // DOLT_MERGE refuses to run with "local changes would be stomped by
+      // merge", so flush whatever is pending into a Dolt commit before
+      // merging. Gate on dolt_status so the common (clean working set)
+      // case doesn't add a noisy "pre-merge flush" entry on every task.
+      //
+      // Stage only memory tables, not -A: even with the lock held, residue
+      // in task_log / execution_log etc. (written under autocommit=0 by
+      // other code paths and not yet Dolt-committed) must not be authored
+      // under this session. The lock + table list together guarantee
+      // attribution is correct.
+      const [statusRows] = await conn.query("SELECT 1 FROM dolt_status LIMIT 1");
+      if ((statusRows as unknown[]).length > 0) {
+        try {
+          await doltCommit(
+            {
+              message: `session:${session.taskId} | pre-merge flush`,
+              author: "haol-memory <haol@system>",
+              tables: MEMORY_TABLES,
+            },
+            conn,
+          );
+        } catch (err) {
+          // Swallow "nothing to commit" — dolt_status can show rows in
+          // tables outside MEMORY_TABLES (which we deliberately don't
+          // stage) so the staged set may be empty. Real failures still
+          // surface from the merge attempt below.
+          if (!(err as Error).message?.includes("nothing to commit")) {
+            throw err;
+          }
+        }
+      }
+      const mergeResult = await doltMerge(session.branch, conn);
+      if (mergeResult.conflicts > 0) {
+        // Resolve with --ours strategy by committing as-is
         await doltCommit(
           {
-            message: `session:${session.taskId} | pre-merge flush`,
+            message: `session:${session.taskId} | merge (conflicts resolved with --ours)`,
             author: "haol-memory <haol@system>",
+            allowEmpty: true,
+            tables: MEMORY_TABLES,
           },
           conn,
         );
-      } catch (err) {
-        // dolt_status can show rows that -A can't stage (e.g. unresolved
-        // merge conflicts, schema-only changes). Swallow "nothing to
-        // commit" so the merge attempt below proceeds and surfaces the
-        // real error if it can't be performed.
-        if (!(err as Error).message?.includes("nothing to commit")) {
-          throw err;
-        }
       }
-    }
-    const mergeResult = await doltMerge(session.branch, conn);
-    if (mergeResult.conflicts > 0) {
-      // Resolve with --ours strategy by committing as-is
-      await doltCommit(
-        {
-          message: `session:${session.taskId} | merge (conflicts resolved with --ours)`,
-          author: "haol-memory <haol@system>",
-          allowEmpty: true,
-        },
-        conn,
+      await doltDeleteBranch(session.branch, conn);
+      return true;
+    });
+
+    if (ran === null) {
+      // Lock contention — leave the session branch in place. Memory work
+      // is best-effort: branch-cleanup will reclaim it on retention expiry,
+      // and a future commitSession call won't be affected.
+      throw new Error(
+        `commitSession: could not acquire ${MAIN_MERGE_LOCK} within ${MAIN_MERGE_LOCK_TIMEOUT_SECONDS}s`,
       );
     }
-    await doltDeleteBranch(session.branch, conn);
   });
 }
 

--- a/tests/db/dolt.test.ts
+++ b/tests/db/dolt.test.ts
@@ -87,9 +87,7 @@ describe("dolt helpers", () => {
       );
 
       // dolt_status should still show handoff_summary as dirty.
-      const [statusRows] = await conn.query<RowDataPacket[]>(
-        "SELECT table_name FROM dolt_status",
-      );
+      const [statusRows] = await conn.query<RowDataPacket[]>("SELECT table_name FROM dolt_status");
       const dirtyTables = statusRows.map((r) => r.table_name as string);
       expect(dirtyTables).toContain("handoff_summary");
       expect(dirtyTables).not.toContain("session_context");

--- a/tests/db/dolt.test.ts
+++ b/tests/db/dolt.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import type { RowDataPacket } from "mysql2/promise";
 import { createPool, getPool, destroy, withBranchConnection } from "../../src/db/connection.js";
 import {
   doltCommit,
@@ -9,6 +10,7 @@ import {
   doltActiveBranch,
 } from "../../src/db/dolt.js";
 import { loadConfig } from "../../src/config.js";
+import { runMigrations } from "../../src/db/migrate.js";
 
 let doltAvailable = false;
 
@@ -23,6 +25,7 @@ beforeAll(async () => {
     const pool = getPool();
     await pool.query("SELECT 1");
     doltAvailable = true;
+    await runMigrations();
   } catch (err) {
     console.warn("Dolt not available — skipping dolt integration tests");
     console.warn("Error:", (err as Error).message);
@@ -49,6 +52,72 @@ describe("dolt helpers", () => {
     });
     expect(hash).toBeTruthy();
     expect(typeof hash).toBe("string");
+  });
+
+  it("doltCommit with tables[] stages only the listed tables", async ({ skip }) => {
+    if (!doltAvailable) skip();
+
+    // Use an isolated branch so we don't fight with the rest of the suite
+    // for working-set state on main.
+    const testBranch = `test/dolt-tables-${Date.now()}`;
+    const taskId = `dolt-tables-${Date.now()}`;
+
+    await withBranchConnection(async (conn) => {
+      await doltBranch({ name: testBranch }, conn);
+      await doltCheckout(testBranch, conn);
+
+      // Dirty two tables: session_context and handoff_summary.
+      await conn.query(
+        "INSERT INTO session_context (session_id, `key`, value) VALUES (?, 'k', JSON_OBJECT())",
+        [taskId],
+      );
+      await conn.query(
+        "INSERT INTO handoff_summary (task_id, from_agent_id, summary) VALUES (?, 'agent-x', 's')",
+        [taskId],
+      );
+
+      // Commit only session_context.
+      await doltCommit(
+        {
+          message: "test: commit only session_context",
+          author: "haol-test <test@haol>",
+          tables: ["session_context"],
+        },
+        conn,
+      );
+
+      // dolt_status should still show handoff_summary as dirty.
+      const [statusRows] = await conn.query<RowDataPacket[]>(
+        "SELECT table_name FROM dolt_status",
+      );
+      const dirtyTables = statusRows.map((r) => r.table_name as string);
+      expect(dirtyTables).toContain("handoff_summary");
+      expect(dirtyTables).not.toContain("session_context");
+
+      // Cleanup: stage and commit the rest, return to main, drop branch.
+      await doltCommit(
+        {
+          message: "test: cleanup",
+          author: "haol-test <test@haol>",
+          allowEmpty: true,
+        },
+        conn,
+      );
+      await conn.query("DELETE FROM session_context WHERE session_id = ?", [taskId]);
+      await conn.query("DELETE FROM handoff_summary WHERE task_id = ?", [taskId]);
+      await doltCommit(
+        {
+          message: "test: clear test rows",
+          author: "haol-test <test@haol>",
+          allowEmpty: true,
+        },
+        conn,
+      );
+      await doltCheckout("main", conn);
+      // Force-delete: this branch was deliberately not merged into main, so
+      // the safe `-d` form would refuse.
+      await conn.query("CALL DOLT_BRANCH('-D', ?)", [testBranch]);
+    });
   });
 
   it("doltBranch + doltCheckout + doltMerge lifecycle", async ({ skip }) => {

--- a/tests/memory/session-manager.test.ts
+++ b/tests/memory/session-manager.test.ts
@@ -175,6 +175,58 @@ describe("session manager", () => {
     await commitSession(sessionB);
   });
 
+  it("commitSession surfaces a clear error when the merge lock is held elsewhere", async ({
+    skip,
+  }) => {
+    if (!doltAvailable) skip();
+
+    // Hold the advisory lock from a side connection so the commitSession
+    // call below times out trying to acquire it. The lock name and 5s
+    // timeout are coupled to the constants in session-manager.ts; if those
+    // change, this test will either need updating or will hang for longer.
+    const pool = getPool();
+    const sideConn = await pool.getConnection();
+    let session: { taskId: string; branch: string } | null = null;
+    try {
+      const [holdRows] = await sideConn.query<RowDataPacket[]>(
+        "SELECT GET_LOCK('haol_merge_main', 0) AS acquired",
+      );
+      // GET_LOCK with 0s timeout returns 1 immediately if free.
+      expect(holdRows[0]?.acquired).toBe(1);
+
+      const lockedTaskId = `mem-locked-${Date.now()}`;
+      session = await createSession(lockedTaskId);
+      await writeContext(session, "k", "v");
+
+      // commitSession should throw after waiting MAIN_MERGE_LOCK_TIMEOUT_SECONDS.
+      await expect(commitSession(session)).rejects.toThrow(/could not acquire/i);
+
+      // Branch must remain — data is on the session branch, recoverable
+      // by branch-cleanup retention or a follow-up commitSession once the
+      // lock is free.
+      const [branches] = await pool.query<RowDataPacket[]>(
+        "SELECT name FROM dolt_branches WHERE name = ?",
+        [session.branch],
+      );
+      expect(branches.length).toBe(1);
+    } finally {
+      try {
+        await sideConn.query("SELECT RELEASE_LOCK('haol_merge_main')");
+      } catch {
+        // best-effort cleanup
+      }
+      sideConn.release();
+      // Drop the leftover session branch so other tests aren't surprised.
+      if (session) {
+        try {
+          await pool.query("CALL DOLT_BRANCH('-D', ?)", [session.branch]);
+        } catch {
+          // best-effort
+        }
+      }
+    }
+  });
+
   it("parallel commitSession calls all succeed under the merge lock", async ({ skip }) => {
     if (!doltAvailable) skip();
 

--- a/tests/memory/session-manager.test.ts
+++ b/tests/memory/session-manager.test.ts
@@ -45,7 +45,8 @@ afterAll(async () => {
       await pool.query("CALL DOLT_CHECKOUT('main')");
     }
 
-    // Clean up any leftover branches
+    // Clean up any leftover branches (session/mem-... covers all test ids in
+    // this file; the parallel test uses mem-parallel-... prefixes too).
     const [branches] = await pool.query<RowDataPacket[]>(
       "SELECT name FROM dolt_branches WHERE name LIKE 'session/mem-%'",
     );
@@ -172,6 +173,45 @@ describe("session manager", () => {
     // Commit both
     await commitSession(sessionA);
     await commitSession(sessionB);
+  });
+
+  it("parallel commitSession calls all succeed under the merge lock", async ({ skip }) => {
+    if (!doltAvailable) skip();
+
+    // Regression: two concurrent commitSession calls used to share main's
+    // working set, so X's pre-merge flush could attribute Y's staged changes
+    // to X. The advisory lock around the flush+merge sequence serializes
+    // the dangerous section. Verify both calls complete and both branches
+    // are deleted (i.e. neither task wedged the other).
+
+    const ids = [
+      `mem-parallel-a-${Date.now()}`,
+      `mem-parallel-b-${Date.now()}`,
+      `mem-parallel-c-${Date.now()}`,
+    ];
+    const sessions = await Promise.all(ids.map((id) => createSession(id)));
+    await Promise.all(sessions.map((s, i) => writeContext(s, "k", `v-${i}`)));
+
+    // Run the commits in parallel — the lock should serialize the main
+    // operations without anyone failing.
+    await Promise.all(sessions.map((s) => commitSession(s)));
+
+    // All session branches should be cleaned up.
+    const pool = getPool();
+    const [branches] = await pool.query<RowDataPacket[]>(
+      `SELECT name FROM dolt_branches WHERE name IN (?, ?, ?)`,
+      sessions.map((s) => s.branch),
+    );
+    expect(branches.length).toBe(0);
+
+    // Each session's data is on main.
+    for (let i = 0; i < ids.length; i++) {
+      const [rows] = await pool.query<RowDataPacket[]>(
+        "SELECT value FROM session_context WHERE session_id = ? AND `key` = 'k'",
+        [ids[i]],
+      );
+      expect(rows.length).toBe(1);
+    }
   });
 });
 


### PR DESCRIPTION
## Summary

Closes audit finding **#5** from `code-audit.md` — `commitSession`'s pre-merge flush was using `DOLT_COMMIT -A` against a working set shared across pool connections. Concurrent task X's staged changes could be committed under task Y's identity, breaking the audit-trail guarantee. The code already acknowledged the bug in a caveat block (`session-manager.ts:138-144`).

Two complementary layers:

### 1. Advisory lock around main-branch operations

Wrap the flush + `DOLT_MERGE` + `DOLT_BRANCH('-d')` sequence in `GET_LOCK('haol_merge_main', 5)` / `RELEASE_LOCK(...)`. Connection-scoped, so a process crash doesn't wedge the system — the lock auto-releases on connection close.

If the lock can't be acquired in 5s, `commitSession` throws rather than silently skipping. The router's `bestEffortMemory` wrapper converts that into a logged warning, so the task pipeline is never blocked by memory contention.

### 2. Explicit table list in DOLT_COMMIT

`doltCommit` now accepts an optional `tables: string[]`. When provided, it does `DOLT_ADD(tables...)` then `DOLT_COMMIT('-m', msg, ...)` (no `-A`). `commitSession` passes `['session_context', 'handoff_summary']` so even with the lock held, residue from `task_log` / `execution_log` etc. can never be authored under a memory commit.

Other `doltCommit` callers (migrate, seed, observability cleanup, routing-tuner) keep using the default `-A` path.

The apologetic caveat block is removed — the bug it described is now closed.

## Test plan

- [x] `tests/db/dolt.test.ts` — new test verifies `doltCommit({tables: ['session_context']})` leaves `handoff_summary` dirty in `dolt_status`.
- [x] `tests/memory/session-manager.test.ts` — new test runs 3 `commitSession` calls in parallel via `Promise.all`. All succeed; all session branches are deleted; each task's data lands on main.
- [x] Existing session-manager tests still pass (`createSession`, `writeContext`, `readContext`, `commitSession`, `discardSession`, `concurrent sessions work independently`, handoff round-trip).
- [x] `npm run build` clean.
- [x] `npm run audit` reports 0 production vulnerabilities.

Pre-existing flaky `pollUntilDone` integration tests reproduce on `main` and are unrelated to this change. Side note: the same files report **2 fewer failures** on this branch than on main — the lock makes the cross-task interaction more deterministic.