### PR TITLE
Sanitize provider error bodies before they reach Dolt-tracked tables

### DIFF
--- a/src/providers/anthropic.ts
+++ b/src/providers/anthropic.ts
@@ -4,6 +4,7 @@ import type {
   AgentResponse,
   HealthStatus,
 } from "../types/execution.js";
+import { formatProviderError } from "./error-sanitizer.js";
 
 export class AnthropicProvider implements AgentProvider {
   private apiKey: string;
@@ -45,7 +46,7 @@ export class AnthropicProvider implements AgentProvider {
 
       if (!response.ok) {
         const errorText = await response.text();
-        throw new Error(`Anthropic API error ${response.status}: ${errorText}`);
+        throw new Error(formatProviderError("Anthropic", response.status, errorText));
       }
 
       const data = (await response.json()) as {

--- a/src/providers/error-sanitizer.ts
+++ b/src/providers/error-sanitizer.ts
@@ -1,13 +1,11 @@
 import { logger } from "../logging/logger.js";
 
-// Anthropic / OpenAI / Ollama all return error bodies that may echo request
-// fragments — including the prompt — in their free-form `message` field.
-// That message used to flow through `throw new Error(...)` into
-// task_log.worker_error, execution_log.error_detail, and structured logs,
-// where Dolt commit history makes it immutable. Capture only the structured
-// fields known to be safe (error.type, error.code) for the public message;
-// the raw body goes to debug-level logs only.
+// Raw body is debug-only — anything above debug persists into task_log /
+// execution_log / Dolt history and may carry prompt fragments.
 const RAW_BODY_DEBUG_CAP = 4_000;
+// Cap on each extracted tag (type/code). Defends against an upstream that
+// stuffs prompt fragments into a normally-short field.
+const MAX_TAG_LEN = 64;
 
 interface ParsedError {
   type?: string;
@@ -15,7 +13,7 @@ interface ParsedError {
 }
 
 function safeString(v: unknown): string | undefined {
-  return typeof v === "string" ? v : undefined;
+  return typeof v === "string" ? v.slice(0, MAX_TAG_LEN) : undefined;
 }
 
 function pickError(parsed: unknown): ParsedError {

--- a/src/providers/error-sanitizer.ts
+++ b/src/providers/error-sanitizer.ts
@@ -1,0 +1,48 @@
+import { logger } from "../logging/logger.js";
+
+// Anthropic / OpenAI / Ollama all return error bodies that may echo request
+// fragments — including the prompt — in their free-form `message` field.
+// That message used to flow through `throw new Error(...)` into
+// task_log.worker_error, execution_log.error_detail, and structured logs,
+// where Dolt commit history makes it immutable. Capture only the structured
+// fields known to be safe (error.type, error.code) for the public message;
+// the raw body goes to debug-level logs only.
+const RAW_BODY_DEBUG_CAP = 4_000;
+
+interface ParsedError {
+  type?: string;
+  code?: string;
+}
+
+function safeString(v: unknown): string | undefined {
+  return typeof v === "string" ? v : undefined;
+}
+
+function pickError(parsed: unknown): ParsedError {
+  if (typeof parsed !== "object" || parsed === null) return {};
+  const root = parsed as { error?: unknown };
+  if (typeof root.error !== "object" || root.error === null) return {};
+  const err = root.error as { type?: unknown; code?: unknown };
+  return { type: safeString(err.type), code: safeString(err.code) };
+}
+
+export function formatProviderError(providerName: string, status: number, rawBody: string): string {
+  let parsed: ParsedError = {};
+  try {
+    parsed = pickError(JSON.parse(rawBody));
+  } catch {
+    // Non-JSON body — debug log only, no detail in public message.
+  }
+
+  logger.debug("provider error body", {
+    component: "providers",
+    provider: providerName,
+    status,
+    raw_body: rawBody.slice(0, RAW_BODY_DEBUG_CAP),
+  });
+
+  const tag = [parsed.type, parsed.code].filter(Boolean).join("/");
+  return tag
+    ? `${providerName} API error ${status} (${tag})`
+    : `${providerName} API error ${status}`;
+}

--- a/src/providers/local.ts
+++ b/src/providers/local.ts
@@ -4,6 +4,7 @@ import type {
   AgentResponse,
   HealthStatus,
 } from "../types/execution.js";
+import { formatProviderError } from "./error-sanitizer.js";
 
 export class LocalProvider implements AgentProvider {
   private modelId: string;
@@ -47,7 +48,7 @@ export class LocalProvider implements AgentProvider {
 
       if (!response.ok) {
         const errorText = await response.text();
-        throw new Error(`Ollama API error ${response.status}: ${errorText}`);
+        throw new Error(formatProviderError("Ollama", response.status, errorText));
       }
 
       const data = (await response.json()) as {

--- a/src/providers/openai.ts
+++ b/src/providers/openai.ts
@@ -4,6 +4,7 @@ import type {
   AgentResponse,
   HealthStatus,
 } from "../types/execution.js";
+import { formatProviderError } from "./error-sanitizer.js";
 
 export class OpenAIProvider implements AgentProvider {
   private apiKey: string;
@@ -49,7 +50,7 @@ export class OpenAIProvider implements AgentProvider {
 
       if (!response.ok) {
         const errorText = await response.text();
-        throw new Error(`OpenAI API error ${response.status}: ${errorText}`);
+        throw new Error(formatProviderError("OpenAI", response.status, errorText));
       }
 
       const data = (await response.json()) as {

--- a/tests/providers/error-sanitizer.test.ts
+++ b/tests/providers/error-sanitizer.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "vitest";
+import { formatProviderError } from "../../src/providers/error-sanitizer.js";
+
+describe("formatProviderError", () => {
+  it("includes only provider, status, and error.type when JSON has type", () => {
+    const body = JSON.stringify({
+      type: "error",
+      error: { type: "invalid_request_error", message: "ignore me" },
+    });
+    expect(formatProviderError("Anthropic", 400, body)).toBe(
+      "Anthropic API error 400 (invalid_request_error)",
+    );
+  });
+
+  it("combines error.type and error.code with a slash", () => {
+    const body = JSON.stringify({
+      error: {
+        message: "Rate limit reached for org-xxx",
+        type: "rate_limit_error",
+        code: "rate_limit_exceeded",
+      },
+    });
+    expect(formatProviderError("OpenAI", 429, body)).toBe(
+      "OpenAI API error 429 (rate_limit_error/rate_limit_exceeded)",
+    );
+  });
+
+  it("falls back to status-only when JSON has no recognizable error fields", () => {
+    expect(formatProviderError("OpenAI", 502, '{"unrelated": "shape"}')).toBe(
+      "OpenAI API error 502",
+    );
+  });
+
+  it("falls back to status-only on non-JSON body", () => {
+    expect(formatProviderError("Ollama", 500, "<html>Internal Server Error</html>")).toBe(
+      "Ollama API error 500",
+    );
+  });
+
+  it("does NOT include the free-form error.message even if it would have been long", () => {
+    // Regression: error.message historically echoed prompt fragments
+    // (\"You requested ... <full prompt content> ... which is invalid\").
+    // The sanitizer must drop it from the public string.
+    const promptEcho =
+      "Bad request: you sent prompt='SECRET internal data exfiltrated via prompt injection'";
+    const body = JSON.stringify({
+      error: { type: "invalid_request_error", message: promptEcho },
+    });
+    const formatted = formatProviderError("Anthropic", 400, body);
+    expect(formatted).toBe("Anthropic API error 400 (invalid_request_error)");
+    expect(formatted).not.toContain("SECRET");
+    expect(formatted).not.toContain("prompt");
+  });
+
+  it("ignores non-string type/code values", () => {
+    const body = JSON.stringify({ error: { type: 42, code: { nested: true } } });
+    expect(formatProviderError("Anthropic", 400, body)).toBe("Anthropic API error 400");
+  });
+
+  it("handles empty body", () => {
+    expect(formatProviderError("Anthropic", 504, "")).toBe("Anthropic API error 504");
+  });
+});

--- a/tests/providers/error-sanitizer.test.ts
+++ b/tests/providers/error-sanitizer.test.ts
@@ -60,4 +60,14 @@ describe("formatProviderError", () => {
   it("handles empty body", () => {
     expect(formatProviderError("Anthropic", 504, "")).toBe("Anthropic API error 504");
   });
+
+  it("caps extracted type/code at 64 chars (defends against prompt-stuffed fields)", () => {
+    // An upstream that misbehaves and dumps prompt content into the type
+    // field should still be bounded.
+    const longType = "x".repeat(200) + "_SECRET_PROMPT_FRAGMENT";
+    const body = JSON.stringify({ error: { type: longType } });
+    const formatted = formatProviderError("Anthropic", 400, body);
+    expect(formatted).toBe(`Anthropic API error 400 (${"x".repeat(64)})`);
+    expect(formatted).not.toContain("SECRET");
+  });
 });


### PR DESCRIPTION
## Summary

Closes audit finding **#6** from `code-audit.md`. Anthropic, OpenAI, and Ollama all return error bodies whose free-form `error.message` field may echo request fragments — including the prompt. The previous `throw new Error(\`...: \${errorText}\`)` pattern flowed that text into:

- `task_log.worker_error`
- `execution_log.error_detail`
- structured logs

…and Dolt's commit history makes those columns immutable. A 400 Anthropic response on a sensitive prompt could leak fragments of that prompt into the audit trail forever.

## Changes

- **New shared helper `src/providers/error-sanitizer.ts`**. `formatProviderError(providerName, status, rawBody)` parses the body as JSON, picks out only `error.type` and `error.code` (string-typed) for the public message, and emits the raw body to `logger.debug` (capped at 4KB). Public format:
  - `Anthropic API error 400 (invalid_request_error)`
  - `OpenAI API error 429 (rate_limit_error/rate_limit_exceeded)`
  - `Ollama API error 500` (no recognizable shape → status only)
- **All three provider files** (`anthropic.ts:48`, `openai.ts:52`, `local.ts:50`) now route through the helper.

## Test plan

- [x] `npm run build` clean
- [x] `npm run format:check` clean
- [x] New `tests/providers/error-sanitizer.test.ts` (7 tests) covers:
  - JSON with `error.type` only
  - JSON with `error.type` + `error.code`
  - JSON missing the `error` shape (status-only fallback)
  - Non-JSON body (status-only fallback)
  - **Regression: prompt-echo body must not appear in public message** (asserts the secret string is absent)
  - Non-string `type`/`code` rejected
  - Empty body
- [x] Existing provider tests (`tests/providers/anthropic.test.ts`, `openai.test.ts`) still pass — they only assert the `"Anthropic API error 500"` prefix, which the new format preserves.
- [x] Full suite: 466/466 passing across 48 files.

## Compat note

The exception message format changes (no longer ends with `: <body>`). Code that string-matches on the body content would break — none in this repo does (the only existing assertions check the `"<Provider> API error <status>"` prefix). External log scrapers that parsed the body out of the message will need to switch to debug-level logs instead.