### PR TITLE
Branch cleanup: guard against pruning active-task branches

### DIFF
--- a/src/memory/branch-cleanup.ts
+++ b/src/memory/branch-cleanup.ts
@@ -67,15 +67,26 @@ async function findActiveTaskIds(taskIds: string[]): Promise<Set<string>> {
   const placeholders = taskIds.map(() => "?").join(", ");
   // Rows with no task_log entry (orphans) and rows in terminal states are
   // both safe to prune; only non-terminal rows protect a branch.
-  const [rows] = await pool.query<TaskStatusRow[]>(
-    `SELECT task_id, status FROM task_log WHERE task_id IN (${placeholders})`,
-    taskIds,
-  );
-  const active = new Set<string>();
-  for (const row of rows) {
-    if (!TERMINAL_STATUSES.has(row.status)) {
-      active.add(row.task_id);
+  // Fail-safe on query error: treat every candidate as active so a transient
+  // Dolt blip can never cause us to delete a live-task branch. The reaper
+  // retries on its next interval, so missed pruning is just deferred.
+  try {
+    const [rows] = await pool.query<TaskStatusRow[]>(
+      `SELECT task_id, status FROM task_log WHERE task_id IN (${placeholders})`,
+      taskIds,
+    );
+    const active = new Set<string>();
+    for (const row of rows) {
+      if (!TERMINAL_STATUSES.has(row.status)) {
+        active.add(row.task_id);
+      }
     }
+    return active;
+  } catch (err) {
+    logger.warn("active-task guard query failed; skipping prune this sweep", {
+      component: "memory",
+      error: (err as Error).message,
+    });
+    return new Set(taskIds);
   }
-  return active;
 }

--- a/src/memory/branch-cleanup.ts
+++ b/src/memory/branch-cleanup.ts
@@ -1,5 +1,6 @@
-import { query, getPool } from "../db/connection.js";
+import { getPool } from "../db/connection.js";
 import { doltDeleteBranch } from "../db/dolt.js";
+import { logger } from "../logging/logger.js";
 import type { RowDataPacket } from "mysql2/promise";
 
 interface BranchRow extends RowDataPacket {
@@ -7,29 +8,74 @@ interface BranchRow extends RowDataPacket {
   latest_commit_date: string;
 }
 
+interface TaskStatusRow extends RowDataPacket {
+  task_id: string;
+  status: string;
+}
+
+const TERMINAL_STATUSES = new Set(["COMPLETED", "FAILED"]);
+const SESSION_BRANCH_PREFIX = "session/";
+
 export async function pruneSessionBranches(retentionDays: number): Promise<string[]> {
   const pool = getPool();
 
-  // Query dolt_branches for session/* branches
   const [rows] = await pool.query<BranchRow[]>(
     `SELECT name, latest_commit_date FROM dolt_branches WHERE name LIKE 'session/%'`,
   );
 
   const cutoff =
-    retentionDays > 0 ? new Date(Date.now() - retentionDays * 24 * 60 * 60 * 1000) : null; // null means prune all
-  const pruned: string[] = [];
+    retentionDays > 0 ? new Date(Date.now() - retentionDays * 24 * 60 * 60 * 1000) : null;
+  const candidates = rows.filter(
+    (row) => cutoff === null || new Date(row.latest_commit_date) <= cutoff,
+  );
 
-  for (const row of rows) {
-    const shouldPrune = cutoff === null || new Date(row.latest_commit_date) <= cutoff;
-    if (shouldPrune) {
-      try {
-        await doltDeleteBranch(row.name);
-        pruned.push(row.name);
-      } catch {
-        // Branch may have already been deleted or is checked out
-      }
+  // Active-task guard: a session/{taskId} branch must not be deleted while
+  // the task is still in flight, or the next memory step surfaces a cryptic
+  // Dolt "branch not found" error. One batched lookup keeps this cheap even
+  // when the candidate list grows large.
+  const taskIds = candidates.map((c) => c.name.slice(SESSION_BRANCH_PREFIX.length));
+  const activeIds = taskIds.length > 0 ? await findActiveTaskIds(taskIds) : new Set<string>();
+
+  const pruned: string[] = [];
+  for (const row of candidates) {
+    const taskId = row.name.slice(SESSION_BRANCH_PREFIX.length);
+    if (activeIds.has(taskId)) {
+      logger.debug("skipped active session branch", {
+        component: "memory",
+        branch: row.name,
+        task_id: taskId,
+      });
+      continue;
+    }
+    try {
+      await doltDeleteBranch(row.name);
+      pruned.push(row.name);
+    } catch (err) {
+      logger.warn("failed to delete session branch", {
+        component: "memory",
+        branch: row.name,
+        error: (err as Error).message,
+      });
     }
   }
 
   return pruned;
+}
+
+async function findActiveTaskIds(taskIds: string[]): Promise<Set<string>> {
+  const pool = getPool();
+  const placeholders = taskIds.map(() => "?").join(", ");
+  // Rows with no task_log entry (orphans) and rows in terminal states are
+  // both safe to prune; only non-terminal rows protect a branch.
+  const [rows] = await pool.query<TaskStatusRow[]>(
+    `SELECT task_id, status FROM task_log WHERE task_id IN (${placeholders})`,
+    taskIds,
+  );
+  const active = new Set<string>();
+  for (const row of rows) {
+    if (!TERMINAL_STATUSES.has(row.status)) {
+      active.add(row.task_id);
+    }
+  }
+  return active;
 }

--- a/tests/memory/branch-cleanup.test.ts
+++ b/tests/memory/branch-cleanup.test.ts
@@ -43,6 +43,8 @@ afterAll(async () => {
         // ignore
       }
     }
+    // Clean up any task_log rows seeded by the active-task-guard tests.
+    await pool.query("DELETE FROM task_log WHERE task_id LIKE 'cleanup-%'");
   }
   await destroy();
 });
@@ -92,5 +94,65 @@ describe("branch cleanup", () => {
     } catch {
       // ignore
     }
+  });
+
+  it("never prunes a branch whose task is still in flight (active-task guard)", async ({
+    skip,
+  }) => {
+    if (!doltAvailable) skip();
+
+    // Regression: previously the sweep deleted any session/% branch older
+    // than the cutoff regardless of task state, so a long-running tier-4
+    // task whose memory branch happened to be older than the retention
+    // window would surface a cryptic Dolt "branch not found" on its next
+    // memory step.
+
+    const pool = getPool();
+    const taskId = `cleanup-active-${Date.now()}`;
+    const branchName = `session/${taskId}`;
+    await doltBranch({ name: branchName });
+    // Seed a non-terminal task_log row. status=DISPATCHED is the most
+    // representative in-flight state.
+    await pool.query(
+      `INSERT INTO task_log (task_id, status, prompt_hash) VALUES (?, 'DISPATCHED', ?)`,
+      [taskId, "deadbeef"],
+    );
+
+    const pruned = await pruneSessionBranches(0);
+    expect(pruned).not.toContain(branchName);
+
+    const [after] = await pool.query<RowDataPacket[]>(
+      "SELECT name FROM dolt_branches WHERE name = ?",
+      [branchName],
+    );
+    expect(after.length).toBe(1);
+  });
+
+  it("prunes a branch whose task has reached a terminal state", async ({ skip }) => {
+    if (!doltAvailable) skip();
+
+    const pool = getPool();
+    const taskId = `cleanup-terminal-${Date.now()}`;
+    const branchName = `session/${taskId}`;
+    await doltBranch({ name: branchName });
+    await pool.query(
+      `INSERT INTO task_log (task_id, status, prompt_hash) VALUES (?, 'COMPLETED', ?)`,
+      [taskId, "deadbeef"],
+    );
+
+    const pruned = await pruneSessionBranches(0);
+    expect(pruned).toContain(branchName);
+  });
+
+  it("prunes orphan branches (no matching task_log row)", async ({ skip }) => {
+    if (!doltAvailable) skip();
+
+    // Branch with no corresponding task_log row — safe to reclaim.
+    const taskId = `cleanup-orphan-${Date.now()}`;
+    const branchName = `session/${taskId}`;
+    await doltBranch({ name: branchName });
+
+    const pruned = await pruneSessionBranches(0);
+    expect(pruned).toContain(branchName);
   });
 });

--- a/tests/memory/branch-cleanup.test.ts
+++ b/tests/memory/branch-cleanup.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
 import { createPool, getPool, query, destroy } from "../../src/db/connection.js";
 import { loadConfig } from "../../src/config.js";
 import { runMigrations } from "../../src/db/migrate.js";
@@ -154,5 +154,44 @@ describe("branch cleanup", () => {
 
     const pruned = await pruneSessionBranches(0);
     expect(pruned).toContain(branchName);
+  });
+
+  it("fails safe: when the active-task lookup throws, no branch is pruned", async ({ skip }) => {
+    if (!doltAvailable) skip();
+
+    // Regression: a transient Dolt failure during the active-task guard
+    // query should never cascade into deleting live branches. The
+    // implementation treats every candidate as active in that case so the
+    // sweep is a no-op; the reaper retries on its next interval.
+    const pool = getPool();
+    const taskId = `cleanup-failsafe-${Date.now()}`;
+    const branchName = `session/${taskId}`;
+    await doltBranch({ name: branchName });
+
+    // Stub the second pool.query call (the task_log lookup) to throw,
+    // letting the first call (dolt_branches list) go through unchanged.
+    const realQuery = pool.query.bind(pool);
+    let calls = 0;
+    const spy = vi.spyOn(pool, "query").mockImplementation(((sql: string, params?: unknown) => {
+      calls++;
+      if (calls === 2) {
+        return Promise.reject(new Error("simulated dolt timeout"));
+      }
+      return realQuery(sql, params as never);
+    }) as unknown as typeof pool.query);
+
+    try {
+      const pruned = await pruneSessionBranches(0);
+      expect(pruned).not.toContain(branchName);
+    } finally {
+      spy.mockRestore();
+    }
+
+    // Branch must still exist after the failed sweep.
+    const [after] = await pool.query<RowDataPacket[]>(
+      "SELECT name FROM dolt_branches WHERE name = ?",
+      [branchName],
+    );
+    expect(after.length).toBe(1);
   });
 });


### PR DESCRIPTION
## Summary

Closes audit finding **#9** from `code-audit.md`. `pruneSessionBranches` (`src/memory/branch-cleanup.ts:14-32`) deleted any `session/%` branch whose `latest_commit_date` was older than the cutoff *regardless of whether the corresponding task was still in flight*. A long-running tier-4 task whose memory branch aged past the retention window would have its branch yanked mid-flight — the next memory step would then surface a cryptic Dolt "branch not found" error, made harder to diagnose by the silently-swallowed `try/catch`.

## Changes

**`src/memory/branch-cleanup.ts`:**
- Extract the candidate set first, then make one batched `SELECT task_id, status FROM task_log WHERE task_id IN (...)` to find the active set.
- Skip prune when the task is in any non-terminal status (`QUEUED`, `RECEIVED`, `CLASSIFIED`, `DISPATCHED`). `COMPLETED`/`FAILED` rows and orphan branches (no matching `task_log` row) still prune.
- Replace silent `catch {}` with structured `logger.warn`/`logger.debug` so future failures are visible:
  - `debug "skipped active session branch"` — guard fired
  - `warn "failed to delete session branch"` — actual Dolt failure

**`tests/memory/branch-cleanup.test.ts`:** three new tests covering:
- **Active-task guard** — branch with `DISPATCHED` task_log row is preserved even with `retentionDays=0`.
- **Terminal-state passthrough** — branch with `COMPLETED` task_log row is pruned.
- **Orphan handling** — branch with no matching `task_log` row is pruned.

## Test plan

- [x] `npm run build` clean
- [x] `npm run format:check` clean
- [x] All 5 branch-cleanup tests pass (2 existing + 3 new)
- [x] Full suite: 464/464 active passing across 48 files (6 intentional skips)

## Performance note

The batched `WHERE task_id IN (...)` lookup is `O(1)` round-trips per sweep regardless of branch count. The existing index on `task_log.task_id` (PK) covers the lookup. No new indexes needed.