### PR TITLE
Drop allowEmpty from routerCommit (audit #15)

### DIFF
--- a/src/router/router.ts
+++ b/src/router/router.ts
@@ -38,9 +38,10 @@ export const DEFAULT_TIMEOUT_MS: Record<ComplexityTier, number> = {
 };
 
 async function routerCommit(message: string): Promise<void> {
-  // allowEmpty: true ensures every task gets a Dolt commit for the audit trail,
-  // even when the working set is clean (e.g., read-only classification).
-  await commitSafely(message, "haol-router <haol@system>", true);
+  // No allowEmpty: a task with no row changes (read-only classification,
+  // pipeline aborted before any write) shouldn't add a commit-message-only
+  // entry to dolt_log. commitSafely silently swallows "nothing to commit".
+  await commitSafely(message, "haol-router <haol@system>");
 }
 
 // Memory layer is best-effort: each step is bounded by MEMORY_STEP_TIMEOUT_MS,

--- a/tests/db/dolt.test.ts
+++ b/tests/db/dolt.test.ts
@@ -8,6 +8,7 @@ import {
   doltDeleteBranch,
   doltMerge,
   doltActiveBranch,
+  commitSafely,
 } from "../../src/db/dolt.js";
 import { loadConfig } from "../../src/config.js";
 import { runMigrations } from "../../src/db/migrate.js";
@@ -52,6 +53,36 @@ describe("dolt helpers", () => {
     });
     expect(hash).toBeTruthy();
     expect(typeof hash).toBe("string");
+  });
+
+  it("commitSafely (no allowEmpty) is a no-op when working set is clean", async ({ skip }) => {
+    if (!doltAvailable) skip();
+
+    // Regression for audit #15: routerCommit dropped allowEmpty so a task
+    // with no row changes shouldn't add a message-only entry to dolt_log.
+    // commitSafely's responsibility is to swallow "nothing to commit"
+    // silently; verify dolt_log doesn't grow when the working set is clean.
+    const pool = getPool();
+
+    // Ensure a clean baseline: flush whatever is staged so the next attempt
+    // is genuinely empty.
+    await commitSafely("test: baseline flush before empty-commit assertion", "test <t@t>", true);
+
+    const [beforeRows] = (await pool.query("SELECT COUNT(*) AS n FROM dolt_log")) as [
+      Array<{ n: number }>,
+    ];
+    const before = Number(beforeRows[0].n);
+
+    await commitSafely(
+      "test: this commit should NOT appear in dolt_log",
+      "test <t@t>",
+      // allowEmpty defaults to false
+    );
+
+    const [afterRows] = (await pool.query("SELECT COUNT(*) AS n FROM dolt_log")) as [
+      Array<{ n: number }>,
+    ];
+    expect(Number(afterRows[0].n)).toBe(before);
   });
 
   it("doltCommit with tables[] stages only the listed tables", async ({ skip }) => {


### PR DESCRIPTION
## Summary

Closes audit finding **#15** from `code-audit.md`. `routerCommit` (`src/router/router.ts:40-44`) called `commitSafely(..., allowEmpty=true)` for every task, so a task with no row changes (read-only classification, pipeline aborted before any write) added a commit-message-only entry to `dolt_log`. After 1M tasks `dolt_log` becomes a million-row haystack with no row-level signal beyond commit messages, and observability queries (audit #19) full-scan it by date.

## Changes

**`src/router/router.ts`:** drop the third arg to `commitSafely` so `allowEmpty` defaults to `false`. `commitSafely` already swallows `"nothing to commit"` via `isNothingToCommitError` (added in PR #57), so the empty case becomes a clean no-op with no new error handling.

Tasks that write to `task_log`/`execution_log`/`routing_log` (the steady-state path now that we force `autocommit=1` per PR #58) still produce commits — the message is captured against the actual row changes, which is what the audit trail is supposed to track.

**`tests/db/dolt.test.ts`:** new test asserts `dolt_log` row count is unchanged after a `commitSafely` call with a clean working set. First runs an `allowEmpty=true` flush as baseline, then verifies the no-allowEmpty call is a no-op.

## Test plan

- [x] `npm run build` clean
- [x] `npm run format:check` clean
- [x] All 5 dolt-helper tests pass (4 existing + 1 new regression)
- [x] Full suite: 466/466 active passing across 48 files

## Compat note

This is a behavior change: tasks that do not touch any tracked tables will no longer add a `dolt_log` entry. If any external observability tool counts `dolt_log` entries as "tasks processed", switch to counting `task_log` rows instead — the row data is and was the source of truth.