### PR TITLE
Fast-fail Anthropic/OpenAI providers when API key is missing (audit #12)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,3 +62,7 @@ jobs:
           DOLT_USER: root
           DOLT_PASSWORD: ""
           DOLT_DATABASE: haol
+          # Provider constructors require API keys (audit #12). Tests mock
+          # fetch so these never reach the wire — dummy values are fine.
+          ANTHROPIC_API_KEY: dummy-for-tests
+          OPENAI_API_KEY: dummy-for-tests

--- a/src/providers/anthropic.ts
+++ b/src/providers/anthropic.ts
@@ -5,13 +5,16 @@ import type {
   HealthStatus,
 } from "../types/execution.js";
 import { formatProviderError } from "./error-sanitizer.js";
+import { MissingApiKeyError } from "./errors.js";
 
 export class AnthropicProvider implements AgentProvider {
   private apiKey: string;
   private modelId: string;
 
   constructor(modelId: string) {
-    this.apiKey = process.env.ANTHROPIC_API_KEY || "";
+    const key = process.env.ANTHROPIC_API_KEY;
+    if (!key) throw new MissingApiKeyError("Anthropic", "ANTHROPIC_API_KEY");
+    this.apiKey = key;
     this.modelId = modelId;
   }
 

--- a/src/providers/errors.ts
+++ b/src/providers/errors.ts
@@ -1,0 +1,11 @@
+export class MissingApiKeyError extends Error {
+  readonly providerName: string;
+  readonly envVar: string;
+
+  constructor(providerName: string, envVar: string) {
+    super(`${providerName} provider requires ${envVar} to be set`);
+    this.name = "MissingApiKeyError";
+    this.providerName = providerName;
+    this.envVar = envVar;
+  }
+}

--- a/src/providers/openai.ts
+++ b/src/providers/openai.ts
@@ -5,13 +5,16 @@ import type {
   HealthStatus,
 } from "../types/execution.js";
 import { formatProviderError } from "./error-sanitizer.js";
+import { MissingApiKeyError } from "./errors.js";
 
 export class OpenAIProvider implements AgentProvider {
   private apiKey: string;
   private modelId: string;
 
   constructor(modelId: string) {
-    this.apiKey = process.env.OPENAI_API_KEY || "";
+    const key = process.env.OPENAI_API_KEY;
+    if (!key) throw new MissingApiKeyError("OpenAI", "OPENAI_API_KEY");
+    this.apiKey = key;
     this.modelId = modelId;
   }
 

--- a/tests/providers/missing-api-key.test.ts
+++ b/tests/providers/missing-api-key.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { AnthropicProvider } from "../../src/providers/anthropic.js";
+import { OpenAIProvider } from "../../src/providers/openai.js";
+import { MissingApiKeyError } from "../../src/providers/errors.js";
+
+const ORIG_ANTHROPIC = process.env.ANTHROPIC_API_KEY;
+const ORIG_OPENAI = process.env.OPENAI_API_KEY;
+
+function restore(key: string, original: string | undefined) {
+  if (original === undefined) delete process.env[key];
+  else process.env[key] = original;
+}
+
+describe("provider constructor — missing API key", () => {
+  afterEach(() => {
+    restore("ANTHROPIC_API_KEY", ORIG_ANTHROPIC);
+    restore("OPENAI_API_KEY", ORIG_OPENAI);
+  });
+
+  describe("AnthropicProvider", () => {
+    it("throws MissingApiKeyError when ANTHROPIC_API_KEY is unset", () => {
+      delete process.env.ANTHROPIC_API_KEY;
+      expect(() => new AnthropicProvider("claude-haiku-4-5-20251001")).toThrow(MissingApiKeyError);
+    });
+
+    it("throws MissingApiKeyError when ANTHROPIC_API_KEY is empty string", () => {
+      process.env.ANTHROPIC_API_KEY = "";
+      expect(() => new AnthropicProvider("claude-haiku-4-5-20251001")).toThrow(MissingApiKeyError);
+    });
+
+    it("includes the env var name on the error so operators know what to set", () => {
+      delete process.env.ANTHROPIC_API_KEY;
+      try {
+        new AnthropicProvider("claude-haiku-4-5-20251001");
+        expect.fail("expected constructor to throw");
+      } catch (err) {
+        expect(err).toBeInstanceOf(MissingApiKeyError);
+        const e = err as MissingApiKeyError;
+        expect(e.envVar).toBe("ANTHROPIC_API_KEY");
+        expect(e.providerName).toBe("Anthropic");
+        expect(e.message).toContain("ANTHROPIC_API_KEY");
+      }
+    });
+
+    it("constructs successfully when the key is set", () => {
+      process.env.ANTHROPIC_API_KEY = "sk-test";
+      expect(() => new AnthropicProvider("claude-haiku-4-5-20251001")).not.toThrow();
+    });
+  });
+
+  describe("OpenAIProvider", () => {
+    it("throws MissingApiKeyError when OPENAI_API_KEY is unset", () => {
+      delete process.env.OPENAI_API_KEY;
+      expect(() => new OpenAIProvider("gpt-4o")).toThrow(MissingApiKeyError);
+    });
+
+    it("throws MissingApiKeyError when OPENAI_API_KEY is empty string", () => {
+      process.env.OPENAI_API_KEY = "";
+      expect(() => new OpenAIProvider("gpt-4o")).toThrow(MissingApiKeyError);
+    });
+
+    it("includes the env var name on the error so operators know what to set", () => {
+      delete process.env.OPENAI_API_KEY;
+      try {
+        new OpenAIProvider("gpt-4o");
+        expect.fail("expected constructor to throw");
+      } catch (err) {
+        expect(err).toBeInstanceOf(MissingApiKeyError);
+        const e = err as MissingApiKeyError;
+        expect(e.envVar).toBe("OPENAI_API_KEY");
+        expect(e.providerName).toBe("OpenAI");
+      }
+    });
+
+    it("constructs successfully when the key is set", () => {
+      process.env.OPENAI_API_KEY = "sk-test";
+      expect(() => new OpenAIProvider("gpt-4o")).not.toThrow();
+    });
+  });
+});

--- a/tests/providers/missing-api-key.test.ts
+++ b/tests/providers/missing-api-key.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, afterEach } from "vitest";
 import { AnthropicProvider } from "../../src/providers/anthropic.js";
 import { OpenAIProvider } from "../../src/providers/openai.js";
 import { MissingApiKeyError } from "../../src/providers/errors.js";


### PR DESCRIPTION
## Summary

Closes audit finding **#12** from `code-audit.md`. `process.env.ANTHROPIC_API_KEY || ""` (and the matching OpenAI line) defaulted to an empty string when the env var was unset. The provider then sent requests with an empty `x-api-key` / `Authorization` header, upstream returned 401, and the response body landed in `task_log.worker_error` and `execution_log.error_detail`. Operators had to dig through Dolt commit history to figure out their key was missing.

## Changes

**`src/providers/errors.ts`** — new `MissingApiKeyError` carrying `providerName` and `envVar` so the error message is operator-actionable (`Anthropic provider requires ANTHROPIC_API_KEY to be set`).

**`src/providers/anthropic.ts`, `src/providers/openai.ts`** — throw `MissingApiKeyError` from the constructor when the env var is unset or empty. The first task that gets dispatched to a misconfigured agent fails fast with a clear message; no doomed network call, no 401 body persisted to Dolt.

`LocalProvider` is unchanged — it talks to Ollama on localhost and doesn't take a key.

**`.github/workflows/ci.yml`** — set dummy `ANTHROPIC_API_KEY=dummy-for-tests` / `OPENAI_API_KEY=dummy-for-tests` for the test step. Tests mock `fetch` so the values never reach the wire; they only need to satisfy the constructor. Locally the user's `.env` already has real keys (loaded via `dotenv/config` in vitest's setup).

## Audit caveat

The audit also said "a new provider is constructed per retry" — that's a misread. `getProvider()` is called once in `execute()` *before* the retry loop (`src/services/execution.ts:30`), not inside it. The fast-fail half of the recommendation stands; the hoist half was already done.

## Test plan

- [x] `npm run build` clean
- [x] `npm run format:check` clean
- [x] New `tests/providers/missing-api-key.test.ts` (8 tests) covers:
  - Unset env var → throws `MissingApiKeyError` (both providers)
  - Empty-string env var → throws (both providers)
  - Error carries `envVar` and `providerName` fields
  - Constructor succeeds when env var is set (both providers)
- [x] Existing provider tests (10 tests) still pass — they pick up the keys from `.env` / dummy CI values automatically.
- [x] Full suite: 474/474 active passing across 49 files.