### PR TITLE
Honor fallback_strategy in tryFallbackAgent

### DIFF
--- a/src/router/router.ts
+++ b/src/router/router.ts
@@ -486,7 +486,8 @@ async function tryFallbackAgent(
       logger.warn("TIER_UP requested but task already at top tier; falling through to NEXT_BEST", {
         component: "router",
         task_id: classification.task_id,
-        complexity_tier: classification.complexity_tier,
+        from_tier: classification.complexity_tier,
+        to_tier: null,
       });
     } else {
       // Re-rank against the next-higher tier with its higher cost ceiling.
@@ -521,12 +522,15 @@ async function tryFallbackAgent(
           });
           return { agent_id: next.agent_id };
         }
-        logger.warn("TIER_UP escalation produced no alternative; falling through to NEXT_BEST", {
-          component: "router",
-          task_id: classification.task_id,
-          from_tier: classification.complexity_tier,
-          to_tier: higherTier,
-        });
+        logger.warn(
+          "TIER_UP escalation returned no new agent; using NEXT_BEST from original tier",
+          {
+            component: "router",
+            task_id: classification.task_id,
+            from_tier: classification.complexity_tier,
+            to_tier: higherTier,
+          },
+        );
       } catch (err) {
         logger.warn("TIER_UP escalation failed; falling through to NEXT_BEST", {
           component: "router",

--- a/src/router/router.ts
+++ b/src/router/router.ts
@@ -5,6 +5,7 @@ import { execute } from "../services/execution.js";
 import * as taskLog from "../repositories/task-log.js";
 import { getActivePolicy } from "../repositories/routing-policy.js";
 import { commitSafely } from "../db/dolt.js";
+import { costCeilingForTier } from "../classifier/scoring.js";
 import type { AgentRequest, ExecutionRecord } from "../types/execution.js";
 import type { ComplexityTier, TaskClassification } from "../types/task.js";
 import { uuidv7 } from "../types/task.js";
@@ -160,6 +161,7 @@ export function _resetMemoryInflightForTests(): void {
 
 export const _bestEffortMemoryForTests = bestEffortMemory;
 export const _createMemoryBudgetForTests = createMemoryBudget;
+export const _tryFallbackAgentForTests = tryFallbackAgent;
 
 export interface RouteTaskOptions {
   /**
@@ -292,6 +294,7 @@ export async function routeTask(
       // Try next-best agent if available
       const fallbackSelection = await tryFallbackAgent(
         classification,
+        selection,
         selection.selected_agent_id,
         policy ?? undefined,
       );
@@ -469,19 +472,35 @@ export async function routeTask(
 
 async function tryFallbackAgent(
   classification: TaskClassification,
+  selection: SelectionResult,
   excludeAgentId: string,
   policy?: RoutingPolicy,
 ): Promise<{ agent_id: string } | null> {
-  try {
-    const result = await select(classification, policy);
-    // If the same agent is selected, no point retrying
-    if (result.selected_agent_id === excludeAgentId) {
-      // Try the second-best if available
-      const secondBest = result.scored_candidates.find((c) => c.agent_id !== excludeAgentId);
-      return secondBest ? { agent_id: secondBest.agent_id } : null;
+  // TIER_UP: re-rank against the next-higher tier with its higher cost ceiling.
+  // This is a different candidate set than the original ranking, so we have to
+  // call select() again. At T4 there's no higher tier — fall through to NEXT_BEST.
+  if (policy?.fallback_strategy === "TIER_UP" && classification.complexity_tier < 4) {
+    const higherTier = (classification.complexity_tier + 1) as ComplexityTier;
+    const escalated: TaskClassification = {
+      ...classification,
+      complexity_tier: higherTier,
+      cost_ceiling_usd: costCeilingForTier(higherTier),
+    };
+    try {
+      const result = await select(escalated, policy);
+      if (result.selected_agent_id !== excludeAgentId) {
+        return { agent_id: result.selected_agent_id };
+      }
+      const next = result.scored_candidates.find((c) => c.agent_id !== excludeAgentId);
+      if (next) return { agent_id: next.agent_id };
+      // No higher-tier alternative — fall through to NEXT_BEST below.
+    } catch {
+      // Selection failed at higher tier — fall through to NEXT_BEST.
     }
-    return { agent_id: result.selected_agent_id };
-  } catch {
-    return null;
   }
+
+  // NEXT_BEST (and TIER_UP fall-through): consume the already-ranked candidates
+  // from the original selection. No DB round-trip.
+  const next = selection.scored_candidates.find((c) => c.agent_id !== excludeAgentId);
+  return next ? { agent_id: next.agent_id } : null;
 }

--- a/src/router/router.ts
+++ b/src/router/router.ts
@@ -476,26 +476,50 @@ async function tryFallbackAgent(
   excludeAgentId: string,
   policy?: RoutingPolicy,
 ): Promise<{ agent_id: string } | null> {
-  // TIER_UP: re-rank against the next-higher tier with its higher cost ceiling.
-  // This is a different candidate set than the original ranking, so we have to
-  // call select() again. At T4 there's no higher tier — fall through to NEXT_BEST.
-  if (policy?.fallback_strategy === "TIER_UP" && classification.complexity_tier < 4) {
-    const higherTier = (classification.complexity_tier + 1) as ComplexityTier;
-    const escalated: TaskClassification = {
-      ...classification,
-      complexity_tier: higherTier,
-      cost_ceiling_usd: costCeilingForTier(higherTier),
-    };
-    try {
-      const result = await select(escalated, policy);
-      if (result.selected_agent_id !== excludeAgentId) {
-        return { agent_id: result.selected_agent_id };
+  // ABORT is filtered at the call site, but enforce it at the function
+  // boundary too so the contract doesn't depend on an invisible precondition.
+  if (policy?.fallback_strategy === "ABORT") return null;
+
+  if (policy?.fallback_strategy === "TIER_UP") {
+    // At T4 there's no higher tier — TIER_UP semantics can't apply.
+    if (classification.complexity_tier >= 4) {
+      logger.warn("TIER_UP requested but task already at top tier; falling through to NEXT_BEST", {
+        component: "router",
+        task_id: classification.task_id,
+        complexity_tier: classification.complexity_tier,
+      });
+    } else {
+      // Re-rank against the next-higher tier with its higher cost ceiling.
+      // This is a different candidate set than the original ranking, so we
+      // have to call select() again.
+      const higherTier = (classification.complexity_tier + 1) as ComplexityTier;
+      const escalated: TaskClassification = {
+        ...classification,
+        complexity_tier: higherTier,
+        cost_ceiling_usd: costCeilingForTier(higherTier),
+      };
+      try {
+        const result = await select(escalated, policy);
+        if (result.selected_agent_id !== excludeAgentId) {
+          return { agent_id: result.selected_agent_id };
+        }
+        const next = result.scored_candidates.find((c) => c.agent_id !== excludeAgentId);
+        if (next) return { agent_id: next.agent_id };
+        logger.warn("TIER_UP escalation produced no alternative; falling through to NEXT_BEST", {
+          component: "router",
+          task_id: classification.task_id,
+          from_tier: classification.complexity_tier,
+          to_tier: higherTier,
+        });
+      } catch (err) {
+        logger.warn("TIER_UP escalation failed; falling through to NEXT_BEST", {
+          component: "router",
+          task_id: classification.task_id,
+          from_tier: classification.complexity_tier,
+          to_tier: higherTier,
+          error: (err as Error).message,
+        });
       }
-      const next = result.scored_candidates.find((c) => c.agent_id !== excludeAgentId);
-      if (next) return { agent_id: next.agent_id };
-      // No higher-tier alternative — fall through to NEXT_BEST below.
-    } catch {
-      // Selection failed at higher tier — fall through to NEXT_BEST.
     }
   }
 

--- a/src/router/router.ts
+++ b/src/router/router.ts
@@ -501,10 +501,26 @@ async function tryFallbackAgent(
       try {
         const result = await select(escalated, policy);
         if (result.selected_agent_id !== excludeAgentId) {
+          logger.info("TIER_UP escalation succeeded", {
+            component: "router",
+            task_id: classification.task_id,
+            from_tier: classification.complexity_tier,
+            to_tier: higherTier,
+            agent_id: result.selected_agent_id,
+          });
           return { agent_id: result.selected_agent_id };
         }
         const next = result.scored_candidates.find((c) => c.agent_id !== excludeAgentId);
-        if (next) return { agent_id: next.agent_id };
+        if (next) {
+          logger.info("TIER_UP escalation succeeded (second-best at higher tier)", {
+            component: "router",
+            task_id: classification.task_id,
+            from_tier: classification.complexity_tier,
+            to_tier: higherTier,
+            agent_id: next.agent_id,
+          });
+          return { agent_id: next.agent_id };
+        }
         logger.warn("TIER_UP escalation produced no alternative; falling through to NEXT_BEST", {
           component: "router",
           task_id: classification.task_id,

--- a/src/services/agent-selection.ts
+++ b/src/services/agent-selection.ts
@@ -208,6 +208,9 @@ export async function select(
 
   const winner = sorted[0];
 
+  // SelectionResult.scored_candidates documents that this list is sorted
+  // descending by total_score — `sorted` carries that contract from
+  // sortCandidates() above. Don't reorder before returning.
   return {
     selected_agent_id: winner.agent_id,
     scored_candidates: sorted,

--- a/src/types/selection.ts
+++ b/src/types/selection.ts
@@ -11,6 +11,11 @@ export type ScoredCandidate = z.infer<typeof ScoredCandidate>;
 
 export const SelectionResult = z.object({
   selected_agent_id: z.string(),
+  /**
+   * All candidates that passed the filter, sorted descending by `total_score`
+   * with `agent_id` ascending as the tiebreak. Consumers (e.g. router fallback)
+   * rely on this ordering to pick the next-best agent without re-ranking.
+   */
   scored_candidates: z.array(ScoredCandidate),
   rationale: z.object({
     capability_score: z.number(),

--- a/tests/router/fallback-strategy.test.ts
+++ b/tests/router/fallback-strategy.test.ts
@@ -174,7 +174,7 @@ describe("tryFallbackAgent — policy-aware behavior", () => {
     expect(selectSpy).not.toHaveBeenCalled();
     expect(warnSpy).toHaveBeenCalledWith(
       expect.stringContaining("TIER_UP requested but task already at top tier"),
-      expect.objectContaining({ complexity_tier: 4 }),
+      expect.objectContaining({ from_tier: 4, to_tier: null }),
     );
   });
 
@@ -194,7 +194,7 @@ describe("tryFallbackAgent — policy-aware behavior", () => {
     expect(selectSpy).not.toHaveBeenCalled();
     expect(warnSpy).toHaveBeenCalledWith(
       expect.stringContaining("TIER_UP requested but task already at top tier"),
-      expect.objectContaining({ complexity_tier: 4 }),
+      expect.objectContaining({ from_tier: 4, to_tier: null }),
     );
   });
 
@@ -243,7 +243,7 @@ describe("tryFallbackAgent — policy-aware behavior", () => {
 
     expect(result).toEqual({ agent_id: "agent-b" });
     expect(warnSpy).toHaveBeenCalledWith(
-      expect.stringContaining("TIER_UP escalation produced no alternative"),
+      expect.stringContaining("TIER_UP escalation returned no new agent"),
       expect.objectContaining({ from_tier: 2, to_tier: 3 }),
     );
   });

--- a/tests/router/fallback-strategy.test.ts
+++ b/tests/router/fallback-strategy.test.ts
@@ -105,7 +105,7 @@ describe("tryFallbackAgent — policy-aware behavior", () => {
     expect(result).toBeNull();
   });
 
-  it("TIER_UP: re-runs select() against complexity_tier+1 with bumped cost ceiling", async () => {
+  it("TIER_UP: re-runs select() against complexity_tier+1 with bumped cost ceiling and logs success", async () => {
     const sel = selectionResult("agent-haiku", ["agent-haiku"]);
     const selectSpy = vi.spyOn(agentSelection, "select").mockResolvedValueOnce({
       selected_agent_id: "agent-sonnet",
@@ -113,6 +113,7 @@ describe("tryFallbackAgent — policy-aware behavior", () => {
       rationale: { capability_score: 1, cost_score: 1, latency_score: 1, total_score: 1 },
       fallback_applied: "NONE",
     });
+    const infoSpy = vi.spyOn(logger, "info").mockImplementation(() => {});
 
     const result = await _tryFallbackAgentForTests(
       classification(2),
@@ -127,6 +128,34 @@ describe("tryFallbackAgent — policy-aware behavior", () => {
     expect(escalated.complexity_tier).toBe(3);
     // T3 ceiling per costCeilingForTier
     expect(escalated.cost_ceiling_usd).toBe(0.5);
+    expect(infoSpy).toHaveBeenCalledWith(
+      expect.stringContaining("TIER_UP escalation succeeded"),
+      expect.objectContaining({ from_tier: 2, to_tier: 3, agent_id: "agent-sonnet" }),
+    );
+  });
+
+  it("TIER_UP: when higher-tier select() returns the excluded agent but a second-best exists, picks second-best and logs success", async () => {
+    const sel = selectionResult("agent-a", ["agent-a"]);
+    vi.spyOn(agentSelection, "select").mockResolvedValueOnce({
+      selected_agent_id: "agent-a",
+      scored_candidates: [candidate("agent-a"), candidate("agent-c")],
+      rationale: { capability_score: 1, cost_score: 1, latency_score: 1, total_score: 1 },
+      fallback_applied: "NONE",
+    });
+    const infoSpy = vi.spyOn(logger, "info").mockImplementation(() => {});
+
+    const result = await _tryFallbackAgentForTests(
+      classification(2),
+      sel,
+      "agent-a",
+      policy("TIER_UP"),
+    );
+
+    expect(result).toEqual({ agent_id: "agent-c" });
+    expect(infoSpy).toHaveBeenCalledWith(
+      expect.stringContaining("second-best at higher tier"),
+      expect.objectContaining({ from_tier: 2, to_tier: 3, agent_id: "agent-c" }),
+    );
   });
 
   it("TIER_UP at T4 with no other ranked candidate: logs a warning and returns null", async () => {
@@ -219,22 +248,4 @@ describe("tryFallbackAgent — policy-aware behavior", () => {
     );
   });
 
-  it("TIER_UP: when higher-tier returns a different second-best (excluded primary still leads at higher tier)", async () => {
-    const sel = selectionResult("agent-a", ["agent-a"]);
-    vi.spyOn(agentSelection, "select").mockResolvedValueOnce({
-      selected_agent_id: "agent-a",
-      scored_candidates: [candidate("agent-a"), candidate("agent-c")],
-      rationale: { capability_score: 1, cost_score: 1, latency_score: 1, total_score: 1 },
-      fallback_applied: "NONE",
-    });
-
-    const result = await _tryFallbackAgentForTests(
-      classification(2),
-      sel,
-      "agent-a",
-      policy("TIER_UP"),
-    );
-
-    expect(result).toEqual({ agent_id: "agent-c" });
-  });
 });

--- a/tests/router/fallback-strategy.test.ts
+++ b/tests/router/fallback-strategy.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { _tryFallbackAgentForTests } from "../../src/router/router.js";
+import * as agentSelection from "../../src/services/agent-selection.js";
+import type { TaskClassification } from "../../src/types/task.js";
+import type { RoutingPolicy, SelectionResult, ScoredCandidate } from "../../src/types/selection.js";
+
+function classification(tier: 1 | 2 | 3 | 4): TaskClassification {
+  return {
+    task_id: "t-fallback",
+    prompt_hash: "deadbeef",
+    complexity_tier: tier,
+    required_capabilities: ["summarization"],
+    cost_ceiling_usd: 0.05,
+    routing_layer: "deterministic",
+    routing_confidence: 1,
+  };
+}
+
+function candidate(agent_id: string, total_score = 0.5): ScoredCandidate {
+  return {
+    agent_id,
+    capability_score: 1,
+    cost_score: 1,
+    latency_score: 1,
+    total_score,
+  };
+}
+
+function selectionResult(winner: string, ranked: string[]): SelectionResult {
+  return {
+    selected_agent_id: winner,
+    scored_candidates: ranked.map((id, i) => candidate(id, 1 - i * 0.1)),
+    rationale: { capability_score: 1, cost_score: 1, latency_score: 1, total_score: 1 },
+    fallback_applied: "NONE",
+  };
+}
+
+const policy = (strategy: "NEXT_BEST" | "TIER_UP" | "ABORT"): RoutingPolicy => ({
+  policy_id: "test",
+  weight_capability: 0.5,
+  weight_cost: 0.3,
+  weight_latency: 0.2,
+  fallback_strategy: strategy,
+  max_retries: 2,
+  active: true,
+  weight_outcome: 0,
+});
+
+describe("tryFallbackAgent — policy-aware behavior", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("NEXT_BEST: consumes existing scored_candidates without re-running select()", async () => {
+    const selectSpy = vi.spyOn(agentSelection, "select");
+    const sel = selectionResult("agent-a", ["agent-a", "agent-b", "agent-c"]);
+
+    const result = await _tryFallbackAgentForTests(
+      classification(2),
+      sel,
+      "agent-a",
+      policy("NEXT_BEST"),
+    );
+
+    expect(result).toEqual({ agent_id: "agent-b" });
+    expect(selectSpy).not.toHaveBeenCalled();
+  });
+
+  it("NEXT_BEST: returns null when no other ranked candidate exists", async () => {
+    const sel = selectionResult("agent-a", ["agent-a"]);
+
+    const result = await _tryFallbackAgentForTests(
+      classification(2),
+      sel,
+      "agent-a",
+      policy("NEXT_BEST"),
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it("TIER_UP: re-runs select() against complexity_tier+1 with bumped cost ceiling", async () => {
+    const sel = selectionResult("agent-haiku", ["agent-haiku"]);
+    const selectSpy = vi.spyOn(agentSelection, "select").mockResolvedValueOnce({
+      selected_agent_id: "agent-sonnet",
+      scored_candidates: [candidate("agent-sonnet")],
+      rationale: { capability_score: 1, cost_score: 1, latency_score: 1, total_score: 1 },
+      fallback_applied: "NONE",
+    });
+
+    const result = await _tryFallbackAgentForTests(
+      classification(2),
+      sel,
+      "agent-haiku",
+      policy("TIER_UP"),
+    );
+
+    expect(result).toEqual({ agent_id: "agent-sonnet" });
+    expect(selectSpy).toHaveBeenCalledOnce();
+    const escalated = selectSpy.mock.calls[0][0] as TaskClassification;
+    expect(escalated.complexity_tier).toBe(3);
+    // T3 ceiling per costCeilingForTier
+    expect(escalated.cost_ceiling_usd).toBe(0.5);
+  });
+
+  it("TIER_UP at T4: skips escalation and falls through to NEXT_BEST", async () => {
+    const selectSpy = vi.spyOn(agentSelection, "select");
+    const sel = selectionResult("agent-a", ["agent-a", "agent-b"]);
+
+    const result = await _tryFallbackAgentForTests(
+      classification(4),
+      sel,
+      "agent-a",
+      policy("TIER_UP"),
+    );
+
+    expect(result).toEqual({ agent_id: "agent-b" });
+    expect(selectSpy).not.toHaveBeenCalled();
+  });
+
+  it("TIER_UP: when escalated select() throws, falls through to NEXT_BEST", async () => {
+    const selectSpy = vi
+      .spyOn(agentSelection, "select")
+      .mockRejectedValueOnce(new Error("no agent at T3"));
+    const sel = selectionResult("agent-a", ["agent-a", "agent-b"]);
+
+    const result = await _tryFallbackAgentForTests(
+      classification(2),
+      sel,
+      "agent-a",
+      policy("TIER_UP"),
+    );
+
+    expect(result).toEqual({ agent_id: "agent-b" });
+    expect(selectSpy).toHaveBeenCalledOnce();
+  });
+
+  it("TIER_UP: when higher-tier select() returns only the excluded agent and no alternatives, falls through", async () => {
+    const sel = selectionResult("agent-a", ["agent-a", "agent-b"]);
+    vi.spyOn(agentSelection, "select").mockResolvedValueOnce({
+      selected_agent_id: "agent-a",
+      scored_candidates: [candidate("agent-a")],
+      rationale: { capability_score: 1, cost_score: 1, latency_score: 1, total_score: 1 },
+      fallback_applied: "NONE",
+    });
+
+    const result = await _tryFallbackAgentForTests(
+      classification(2),
+      sel,
+      "agent-a",
+      policy("TIER_UP"),
+    );
+
+    expect(result).toEqual({ agent_id: "agent-b" });
+  });
+
+  it("TIER_UP: when higher-tier returns a different second-best (excluded primary still leads at higher tier)", async () => {
+    const sel = selectionResult("agent-a", ["agent-a"]);
+    vi.spyOn(agentSelection, "select").mockResolvedValueOnce({
+      selected_agent_id: "agent-a",
+      scored_candidates: [candidate("agent-a"), candidate("agent-c")],
+      rationale: { capability_score: 1, cost_score: 1, latency_score: 1, total_score: 1 },
+      fallback_applied: "NONE",
+    });
+
+    const result = await _tryFallbackAgentForTests(
+      classification(2),
+      sel,
+      "agent-a",
+      policy("TIER_UP"),
+    );
+
+    expect(result).toEqual({ agent_id: "agent-c" });
+  });
+});

--- a/tests/router/fallback-strategy.test.ts
+++ b/tests/router/fallback-strategy.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { _tryFallbackAgentForTests } from "../../src/router/router.js";
 import * as agentSelection from "../../src/services/agent-selection.js";
+import { logger } from "../../src/logging/logger.js";
 import type { TaskClassification } from "../../src/types/task.js";
 import type { RoutingPolicy, SelectionResult, ScoredCandidate } from "../../src/types/selection.js";
 
@@ -49,6 +50,21 @@ const policy = (strategy: "NEXT_BEST" | "TIER_UP" | "ABORT"): RoutingPolicy => (
 describe("tryFallbackAgent — policy-aware behavior", () => {
   afterEach(() => {
     vi.restoreAllMocks();
+  });
+
+  it("ABORT: returns null without consulting scored_candidates or select()", async () => {
+    const selectSpy = vi.spyOn(agentSelection, "select");
+    const sel = selectionResult("agent-a", ["agent-a", "agent-b", "agent-c"]);
+
+    const result = await _tryFallbackAgentForTests(
+      classification(2),
+      sel,
+      "agent-a",
+      policy("ABORT"),
+    );
+
+    expect(result).toBeNull();
+    expect(selectSpy).not.toHaveBeenCalled();
   });
 
   it("NEXT_BEST: consumes existing scored_candidates without re-running select()", async () => {
@@ -103,8 +119,9 @@ describe("tryFallbackAgent — policy-aware behavior", () => {
     expect(escalated.cost_ceiling_usd).toBe(0.5);
   });
 
-  it("TIER_UP at T4: skips escalation and falls through to NEXT_BEST", async () => {
+  it("TIER_UP at T4: skips escalation, logs a warning, and falls through to NEXT_BEST", async () => {
     const selectSpy = vi.spyOn(agentSelection, "select");
+    const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
     const sel = selectionResult("agent-a", ["agent-a", "agent-b"]);
 
     const result = await _tryFallbackAgentForTests(
@@ -116,12 +133,17 @@ describe("tryFallbackAgent — policy-aware behavior", () => {
 
     expect(result).toEqual({ agent_id: "agent-b" });
     expect(selectSpy).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("TIER_UP requested but task already at top tier"),
+      expect.objectContaining({ complexity_tier: 4 }),
+    );
   });
 
-  it("TIER_UP: when escalated select() throws, falls through to NEXT_BEST", async () => {
+  it("TIER_UP: when escalated select() throws, logs a warning and falls through to NEXT_BEST", async () => {
     const selectSpy = vi
       .spyOn(agentSelection, "select")
       .mockRejectedValueOnce(new Error("no agent at T3"));
+    const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
     const sel = selectionResult("agent-a", ["agent-a", "agent-b"]);
 
     const result = await _tryFallbackAgentForTests(
@@ -133,9 +155,17 @@ describe("tryFallbackAgent — policy-aware behavior", () => {
 
     expect(result).toEqual({ agent_id: "agent-b" });
     expect(selectSpy).toHaveBeenCalledOnce();
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("TIER_UP escalation failed"),
+      expect.objectContaining({
+        from_tier: 2,
+        to_tier: 3,
+        error: "no agent at T3",
+      }),
+    );
   });
 
-  it("TIER_UP: when higher-tier select() returns only the excluded agent and no alternatives, falls through", async () => {
+  it("TIER_UP: when higher-tier select() returns only the excluded agent, logs a warning and falls through", async () => {
     const sel = selectionResult("agent-a", ["agent-a", "agent-b"]);
     vi.spyOn(agentSelection, "select").mockResolvedValueOnce({
       selected_agent_id: "agent-a",
@@ -143,6 +173,7 @@ describe("tryFallbackAgent — policy-aware behavior", () => {
       rationale: { capability_score: 1, cost_score: 1, latency_score: 1, total_score: 1 },
       fallback_applied: "NONE",
     });
+    const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
 
     const result = await _tryFallbackAgentForTests(
       classification(2),
@@ -152,6 +183,10 @@ describe("tryFallbackAgent — policy-aware behavior", () => {
     );
 
     expect(result).toEqual({ agent_id: "agent-b" });
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("TIER_UP escalation produced no alternative"),
+      expect.objectContaining({ from_tier: 2, to_tier: 3 }),
+    );
   });
 
   it("TIER_UP: when higher-tier returns a different second-best (excluded primary still leads at higher tier)", async () => {

--- a/tests/router/fallback-strategy.test.ts
+++ b/tests/router/fallback-strategy.test.ts
@@ -247,5 +247,4 @@ describe("tryFallbackAgent — policy-aware behavior", () => {
       expect.objectContaining({ from_tier: 2, to_tier: 3 }),
     );
   });
-
 });

--- a/tests/router/fallback-strategy.test.ts
+++ b/tests/router/fallback-strategy.test.ts
@@ -52,6 +52,16 @@ describe("tryFallbackAgent — policy-aware behavior", () => {
     vi.restoreAllMocks();
   });
 
+  it("undefined policy: implicit NEXT_BEST — consumes ranking without calling select()", async () => {
+    const selectSpy = vi.spyOn(agentSelection, "select");
+    const sel = selectionResult("agent-a", ["agent-a", "agent-b"]);
+
+    const result = await _tryFallbackAgentForTests(classification(2), sel, "agent-a", undefined);
+
+    expect(result).toEqual({ agent_id: "agent-b" });
+    expect(selectSpy).not.toHaveBeenCalled();
+  });
+
   it("ABORT: returns null without consulting scored_candidates or select()", async () => {
     const selectSpy = vi.spyOn(agentSelection, "select");
     const sel = selectionResult("agent-a", ["agent-a", "agent-b", "agent-c"]);
@@ -117,6 +127,26 @@ describe("tryFallbackAgent — policy-aware behavior", () => {
     expect(escalated.complexity_tier).toBe(3);
     // T3 ceiling per costCeilingForTier
     expect(escalated.cost_ceiling_usd).toBe(0.5);
+  });
+
+  it("TIER_UP at T4 with no other ranked candidate: logs a warning and returns null", async () => {
+    const selectSpy = vi.spyOn(agentSelection, "select");
+    const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
+    const sel = selectionResult("agent-a", ["agent-a"]);
+
+    const result = await _tryFallbackAgentForTests(
+      classification(4),
+      sel,
+      "agent-a",
+      policy("TIER_UP"),
+    );
+
+    expect(result).toBeNull();
+    expect(selectSpy).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("TIER_UP requested but task already at top tier"),
+      expect.objectContaining({ complexity_tier: 4 }),
+    );
   });
 
   it("TIER_UP at T4: skips escalation, logs a warning, and falls through to NEXT_BEST", async () => {


### PR DESCRIPTION
## Summary

Audit finding #7 from `code-audit.md`: `tryFallbackAgent` re-ran the full agent-selection pipeline on execution failure, with two real bugs:

- **Wasted DB round-trip on the unhappy path.** `select()` was called again from scratch even though `selection.scored_candidates` was already ranked in memory at the call site.
- **`TIER_UP` was silently downgraded to `NEXT_BEST` semantics.** `select()` only escalates the tier when no candidates pass the filter — re-calling it with the same classification produced the same ranking, so an operator who configured `TIER_UP` expecting escalation to a more capable model on execution failure got next-best-at-the-same-tier instead.

## Change

`src/router/router.ts` — `tryFallbackAgent` now branches on `policy.fallback_strategy`:

- **`NEXT_BEST`**: consumes `selection.scored_candidates` directly. No DB round-trip.
- **`TIER_UP`**: re-runs `select()` against `complexity_tier + 1` with the cost ceiling bumped via `costCeilingForTier()`. Falls through to `NEXT_BEST` semantics at T4 (no higher tier) or when escalated selection fails / yields only the excluded agent with no alternative.
- **`ABORT`** continues to be filtered at the call site as before.

## Test plan

New `tests/router/fallback-strategy.test.ts` (mock-driven, no Dolt required, 7 cases):

- [x] NEXT_BEST consumes existing ranking without calling `select()`
- [x] NEXT_BEST returns null when the only candidate is the excluded primary
- [x] TIER_UP escalates to tier+1 with the correct bumped cost ceiling
- [x] TIER_UP at T4 skips escalation and falls through to NEXT_BEST
- [x] TIER_UP falls through when escalated `select()` throws
- [x] TIER_UP falls through when higher-tier ranking is exhausted by exclusion
- [x] TIER_UP returns higher-tier second-best when primary still leads at T+1
- [x] All 26 existing tests in `tests/router/` still pass
- [x] `npm run build` clean