### PR TITLE
Fix API validation and task intake edge cases

### DIFF
--- a/src/api/request-body.ts
+++ b/src/api/request-body.ts
@@ -4,7 +4,10 @@ import { ValidationError } from "./middleware/error-handler.js";
 export async function parseJsonBody(c: Context): Promise<unknown> {
   try {
     return await c.req.json();
-  } catch {
-    throw new ValidationError("Invalid JSON request body");
+  } catch (err) {
+    if (err instanceof SyntaxError) {
+      throw new ValidationError("Invalid JSON request body");
+    }
+    throw err;
   }
 }

--- a/src/api/request-body.ts
+++ b/src/api/request-body.ts
@@ -1,0 +1,10 @@
+import type { Context } from "hono";
+import { ValidationError } from "./middleware/error-handler.js";
+
+export async function parseJsonBody(c: Context): Promise<unknown> {
+  try {
+    return await c.req.json();
+  } catch {
+    throw new ValidationError("Invalid JSON request body");
+  }
+}

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -12,6 +12,14 @@ import { parseJsonBody } from "../request-body.js";
 
 const agents = new Hono();
 
+function mapCapabilityValidationError(err: unknown): never {
+  const message = err instanceof Error ? err.message : String(err);
+  if (message.startsWith("Unknown capabilities:")) {
+    throw new ValidationError(message);
+  }
+  throw err;
+}
+
 agents.get("/agents", async (c) => {
   const status = c.req.query("status");
   const capability = c.req.query("capability");
@@ -30,7 +38,7 @@ agents.post("/agents", async (c) => {
     throw new ValidationError(parsed.error.message);
   }
 
-  const agent = await createAgent(parsed.data);
+  const agent = await createAgent(parsed.data).catch(mapCapabilityValidationError);
   return c.json(agent, 201);
 });
 
@@ -47,7 +55,7 @@ agents.put("/agents/:id", async (c) => {
     throw new NotFoundError(`Agent not found: ${agentId}`);
   }
 
-  const updated = await updateAgent(agentId, parsed.data);
+  const updated = await updateAgent(agentId, parsed.data).catch(mapCapabilityValidationError);
   return c.json(updated, 200);
 });
 

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -8,6 +8,7 @@ import {
 } from "../../services/agent-registry.js";
 import { CreateAgentInput, UpdateAgentInput } from "../../types/agent.js";
 import { NotFoundError, ValidationError } from "../middleware/error-handler.js";
+import { parseJsonBody } from "../request-body.js";
 
 const agents = new Hono();
 
@@ -23,7 +24,7 @@ agents.get("/agents", async (c) => {
 });
 
 agents.post("/agents", async (c) => {
-  const body = await c.req.json();
+  const body = await parseJsonBody(c);
   const parsed = CreateAgentInput.safeParse(body);
   if (!parsed.success) {
     throw new ValidationError(parsed.error.message);
@@ -35,7 +36,7 @@ agents.post("/agents", async (c) => {
 
 agents.put("/agents/:id", async (c) => {
   const agentId = c.req.param("id");
-  const body = await c.req.json();
+  const body = await parseJsonBody(c);
   const parsed = UpdateAgentInput.safeParse(body);
   if (!parsed.success) {
     throw new ValidationError(parsed.error.message);

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -5,6 +5,7 @@ import {
   deleteAgent,
   getAgent,
   listAgents,
+  CapabilityValidationError,
 } from "../../services/agent-registry.js";
 import { CreateAgentInput, UpdateAgentInput } from "../../types/agent.js";
 import { NotFoundError, ValidationError } from "../middleware/error-handler.js";
@@ -13,9 +14,8 @@ import { parseJsonBody } from "../request-body.js";
 const agents = new Hono();
 
 function mapCapabilityValidationError(err: unknown): never {
-  const message = err instanceof Error ? err.message : String(err);
-  if (message.startsWith("Unknown capabilities:")) {
-    throw new ValidationError(message);
+  if (err instanceof CapabilityValidationError) {
+    throw new ValidationError(err.message);
   }
   throw err;
 }

--- a/src/api/routes/demo.ts
+++ b/src/api/routes/demo.ts
@@ -2,6 +2,7 @@ import { Hono } from "hono";
 import { routeTask } from "../../router/router.js";
 import { RouterTaskInput } from "../../types/router.js";
 import { costSavings } from "../../observability/queries.js";
+import { parseJsonBody } from "../request-body.js";
 
 const demo = new Hono();
 
@@ -14,7 +15,7 @@ const DEMO_MAX_TOKENS = 1024;
 const DEMO_TIMEOUT_MS = 15_000;
 
 demo.post("/demo/api/task", async (c) => {
-  const body = await c.req.json();
+  const body = await parseJsonBody(c);
   const parsed = RouterTaskInput.safeParse(body);
   if (!parsed.success) {
     return c.json({ error: parsed.error.message }, 400);

--- a/src/api/routes/outcomes.ts
+++ b/src/api/routes/outcomes.ts
@@ -4,13 +4,14 @@ import { recordDownstreamOutcome } from "../../services/outcome-collector.js";
 import * as outcomeRepo from "../../repositories/task-outcome.js";
 import * as taskLog from "../../repositories/task-log.js";
 import type { OutcomeSummary } from "../../types/outcome.js";
+import { parseJsonBody } from "../request-body.js";
 
 const outcomes = new Hono();
 
 // POST /tasks/:id/outcome — Tier 3 downstream signal
 outcomes.post("/tasks/:id/outcome", async (c) => {
   const taskId = c.req.param("id");
-  const body = await c.req.json();
+  const body = await parseJsonBody(c);
 
   const result = DownstreamOutcomeInput.safeParse(body);
   if (!result.success) {

--- a/src/api/routes/tasks.ts
+++ b/src/api/routes/tasks.ts
@@ -68,6 +68,10 @@ tasks.post("/tasks", async (c) => {
     if (isQueueFull) {
       c.header("Retry-After", "5");
     }
+    // Response intentionally diverges from the standard `{ error }` shape: the
+    // caller already owns a persisted row at this point, so we return task_id
+    // and the row's final status so they can poll or discard rather than
+    // blindly retry and double-spend provider calls.
     return c.json(
       {
         error: "task queue unavailable, retry shortly",

--- a/src/api/routes/tasks.ts
+++ b/src/api/routes/tasks.ts
@@ -45,12 +45,14 @@ tasks.post("/tasks", async (c) => {
   });
   const enqueueResult = worker.enqueue(taskId, parsed.data, c.get("requestId"));
   if (enqueueResult !== "ok") {
+    let persistedStatus: "FAILED" | "QUEUED" = "FAILED";
     // Do not leave hidden recoverable work behind an error response. If the
     // caller retries after this response, the original row must not execute
     // later and double-spend provider calls.
     try {
       await taskLog.recordWorkerError(taskId, `enqueue_failed:${enqueueResult}`);
     } catch (err) {
+      persistedStatus = "QUEUED";
       logger.warn("failed to mark enqueue-failure row as FAILED", {
         component: "tasks-api",
         task_id: taskId,
@@ -66,7 +68,7 @@ tasks.post("/tasks", async (c) => {
       {
         error: "task queue unavailable, retry shortly",
         task_id: taskId,
-        status: "FAILED",
+        status: persistedStatus,
       },
       enqueueResult === "queue_full" ? 429 : 503,
     );

--- a/src/api/routes/tasks.ts
+++ b/src/api/routes/tasks.ts
@@ -55,10 +55,13 @@ tasks.post("/tasks", async (c) => {
         component: "tasks-api",
         task_id: taskId,
         enqueue_result: enqueueResult,
+        db_status: "QUEUED",
         error: (err as Error).message,
       });
     }
-    c.header("Retry-After", "5");
+    if (enqueueResult === "queue_full") {
+      c.header("Retry-After", "5");
+    }
     return c.json(
       {
         error: "task queue unavailable, retry shortly",

--- a/src/api/routes/tasks.ts
+++ b/src/api/routes/tasks.ts
@@ -45,13 +45,14 @@ tasks.post("/tasks", async (c) => {
   });
   const enqueueResult = worker.enqueue(taskId, parsed.data, c.get("requestId"));
   if (enqueueResult !== "ok") {
-    let persistedStatus: "FAILED" | "QUEUED" = "FAILED";
+    let persistedStatus: "FAILED" | "QUEUED";
     let warning: string | undefined;
     // Do not leave hidden recoverable work behind an error response. If the
     // caller retries after this response, the original row must not execute
     // later and double-spend provider calls.
     try {
       await taskLog.recordWorkerError(taskId, `enqueue_failed:${enqueueResult}`);
+      persistedStatus = "FAILED";
     } catch (err) {
       persistedStatus = "QUEUED";
       warning = "task row remains queued and may execute later; poll task_id before retrying";
@@ -63,7 +64,8 @@ tasks.post("/tasks", async (c) => {
         error: (err as Error).message,
       });
     }
-    if (enqueueResult === "queue_full") {
+    const isQueueFull = enqueueResult === "queue_full";
+    if (isQueueFull) {
       c.header("Retry-After", "5");
     }
     return c.json(
@@ -73,7 +75,7 @@ tasks.post("/tasks", async (c) => {
         status: persistedStatus,
         ...(warning ? { warning } : {}),
       },
-      enqueueResult === "queue_full" ? 429 : 503,
+      isQueueFull ? 429 : 503,
     );
   }
 

--- a/src/api/routes/tasks.ts
+++ b/src/api/routes/tasks.ts
@@ -8,6 +8,7 @@ import * as worker from "../../services/task-worker.js";
 import { NotFoundError, ValidationError } from "../middleware/error-handler.js";
 import { parseJsonBody } from "../request-body.js";
 import type { HonoEnv } from "../types.js";
+import { logger } from "../../logging/logger.js";
 
 const tasks = new Hono<HonoEnv>();
 
@@ -47,7 +48,16 @@ tasks.post("/tasks", async (c) => {
     // Do not leave hidden recoverable work behind an error response. If the
     // caller retries after this response, the original row must not execute
     // later and double-spend provider calls.
-    await taskLog.recordWorkerError(taskId, `enqueue_failed:${enqueueResult}`);
+    try {
+      await taskLog.recordWorkerError(taskId, `enqueue_failed:${enqueueResult}`);
+    } catch (err) {
+      logger.warn("failed to mark enqueue-failure row as FAILED", {
+        component: "tasks-api",
+        task_id: taskId,
+        enqueue_result: enqueueResult,
+        error: (err as Error).message,
+      });
+    }
     c.header("Retry-After", "5");
     return c.json(
       {

--- a/src/api/routes/tasks.ts
+++ b/src/api/routes/tasks.ts
@@ -46,6 +46,7 @@ tasks.post("/tasks", async (c) => {
   const enqueueResult = worker.enqueue(taskId, parsed.data, c.get("requestId"));
   if (enqueueResult !== "ok") {
     let persistedStatus: "FAILED" | "QUEUED" = "FAILED";
+    let warning: string | undefined;
     // Do not leave hidden recoverable work behind an error response. If the
     // caller retries after this response, the original row must not execute
     // later and double-spend provider calls.
@@ -53,6 +54,7 @@ tasks.post("/tasks", async (c) => {
       await taskLog.recordWorkerError(taskId, `enqueue_failed:${enqueueResult}`);
     } catch (err) {
       persistedStatus = "QUEUED";
+      warning = "task row remains queued and may execute later; poll task_id before retrying";
       logger.warn("failed to mark enqueue-failure row as FAILED", {
         component: "tasks-api",
         task_id: taskId,
@@ -69,6 +71,7 @@ tasks.post("/tasks", async (c) => {
         error: "task queue unavailable, retry shortly",
         task_id: taskId,
         status: persistedStatus,
+        ...(warning ? { warning } : {}),
       },
       enqueueResult === "queue_full" ? 429 : 503,
     );

--- a/src/api/routes/tasks.ts
+++ b/src/api/routes/tasks.ts
@@ -6,6 +6,7 @@ import { RouterTaskInput } from "../../types/router.js";
 import { uuidv7, sha256 } from "../../types/task.js";
 import * as worker from "../../services/task-worker.js";
 import { NotFoundError, ValidationError } from "../middleware/error-handler.js";
+import { parseJsonBody } from "../request-body.js";
 import type { HonoEnv } from "../types.js";
 
 const tasks = new Hono<HonoEnv>();
@@ -18,7 +19,7 @@ const tasks = new Hono<HonoEnv>();
  * GET /tasks/:id for status.
  */
 tasks.post("/tasks", async (c) => {
-  const body = await c.req.json();
+  const body = await parseJsonBody(c);
   const parsed = RouterTaskInput.safeParse(body);
   if (!parsed.success) {
     throw new ValidationError(parsed.error.message);
@@ -29,7 +30,7 @@ tasks.post("/tasks", async (c) => {
   // instead of silently piling up rows the reaper has to clean later.
   if (!worker.canAccept()) {
     c.header("Retry-After", "5");
-    return c.json({ error: "task queue full, retry shortly" }, 503);
+    return c.json({ error: "task queue full, retry shortly" }, 429);
   }
 
   const taskId = uuidv7();
@@ -43,10 +44,19 @@ tasks.post("/tasks", async (c) => {
   });
   const enqueueResult = worker.enqueue(taskId, parsed.data, c.get("requestId"));
   if (enqueueResult !== "ok") {
-    // Lost the race against another concurrent intake or shutdown — leave
-    // the row QUEUED for the reaper rather than orphaning the caller.
+    // Do not leave hidden recoverable work behind an error response. If the
+    // caller retries after this response, the original row must not execute
+    // later and double-spend provider calls.
+    await taskLog.recordWorkerError(taskId, `enqueue_failed:${enqueueResult}`);
     c.header("Retry-After", "5");
-    return c.json({ error: "task queue unavailable, retry shortly" }, 503);
+    return c.json(
+      {
+        error: "task queue unavailable, retry shortly",
+        task_id: taskId,
+        status: "FAILED",
+      },
+      enqueueResult === "queue_full" ? 429 : 503,
+    );
   }
 
   c.header("Location", `/v1/tasks/${taskId}`);

--- a/src/repositories/agent-registry.ts
+++ b/src/repositories/agent-registry.ts
@@ -1,6 +1,11 @@
 import { query, getPool } from "../db/connection.js";
 import type { RowDataPacket } from "mysql2/promise";
-import type { AgentRegistration, CreateAgentInput, UpdateAgentInput } from "../types/agent.js";
+import {
+  AgentProvider,
+  type AgentRegistration,
+  type CreateAgentInput,
+  type UpdateAgentInput,
+} from "../types/agent.js";
 
 interface AgentRow extends RowDataPacket {
   agent_id: string;
@@ -25,7 +30,7 @@ export function parseAgentRow(row: AgentRow): AgentRegistration {
 
   return {
     agent_id: row.agent_id,
-    provider: row.provider,
+    provider: AgentProvider.parse(row.provider),
     model_id: row.model_id,
     capabilities,
     cost_per_1k_input:

--- a/src/repositories/agent-registry.ts
+++ b/src/repositories/agent-registry.ts
@@ -6,6 +6,7 @@ import {
   type CreateAgentInput,
   type UpdateAgentInput,
 } from "../types/agent.js";
+import { logger } from "../logging/logger.js";
 
 interface AgentRow extends RowDataPacket {
   agent_id: string;
@@ -28,9 +29,18 @@ export function parseAgentRow(row: AgentRow): AgentRegistration {
     capabilities = row.capabilities;
   }
 
+  const provider = AgentProvider.safeParse(row.provider);
+  if (!provider.success) {
+    logger.warn("agent row has unrecognized provider", {
+      component: "agent-registry",
+      agent_id: row.agent_id,
+      provider: row.provider,
+    });
+  }
+
   return {
     agent_id: row.agent_id,
-    provider: AgentProvider.parse(row.provider),
+    provider: provider.success ? provider.data : row.provider,
     model_id: row.model_id,
     capabilities,
     cost_per_1k_input:

--- a/src/services/agent-registry.ts
+++ b/src/services/agent-registry.ts
@@ -12,21 +12,25 @@ async function serviceCommit(message: string): Promise<void> {
   await commitSafely(message, "haol-service <haol@system>");
 }
 
-export async function createAgent(input: CreateAgentInput): Promise<AgentRegistration> {
-  // Validate all capabilities exist in the taxonomy
-  if (input.capabilities.length > 0) {
-    const placeholders = input.capabilities.map(() => "?").join(", ");
+async function validateCapabilities(capabilities: string[]): Promise<void> {
+  if (capabilities.length > 0) {
+    const placeholders = capabilities.map(() => "?").join(", ");
     const rows = await query<CapabilityRow[]>(
       `SELECT capability_key FROM capability_taxonomy WHERE capability_key IN (${placeholders})`,
-      input.capabilities,
+      capabilities,
     );
 
     const found = new Set(rows.map((r) => r.capability_key));
-    const unknown = input.capabilities.filter((c) => !found.has(c));
+    const unknown = capabilities.filter((c) => !found.has(c));
     if (unknown.length > 0) {
       throw new Error(`Unknown capabilities: ${unknown.join(", ")}`);
     }
   }
+}
+
+export async function createAgent(input: CreateAgentInput): Promise<AgentRegistration> {
+  // Validate all capabilities exist in the taxonomy
+  await validateCapabilities(input.capabilities);
 
   await repo.create(input);
   await serviceCommit(`agent: register ${input.agent_id}`);
@@ -39,6 +43,9 @@ export async function updateAgent(
   agentId: string,
   input: UpdateAgentInput,
 ): Promise<AgentRegistration | null> {
+  if (input.capabilities) {
+    await validateCapabilities(input.capabilities);
+  }
   await repo.update(agentId, input);
   await serviceCommit(`agent: update ${agentId}`);
   return repo.findById(agentId);

--- a/src/services/agent-registry.ts
+++ b/src/services/agent-registry.ts
@@ -8,6 +8,13 @@ interface CapabilityRow extends RowDataPacket {
   capability_key: string;
 }
 
+export class CapabilityValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "CapabilityValidationError";
+  }
+}
+
 async function serviceCommit(message: string): Promise<void> {
   await commitSafely(message, "haol-service <haol@system>");
 }
@@ -23,7 +30,7 @@ async function validateCapabilities(capabilities: string[]): Promise<void> {
     const found = new Set(rows.map((r) => r.capability_key));
     const unknown = capabilities.filter((c) => !found.has(c));
     if (unknown.length > 0) {
-      throw new Error(`Unknown capabilities: ${unknown.join(", ")}`);
+      throw new CapabilityValidationError(`Unknown capabilities: ${unknown.join(", ")}`);
     }
   }
 }

--- a/src/types/agent.ts
+++ b/src/types/agent.ts
@@ -8,6 +8,8 @@ export type AgentProvider = z.infer<typeof AgentProvider>;
 
 export const AgentRegistration = z.object({
   agent_id: z.string(),
+  // Intentionally wider than AgentProvider: existing DB rows may contain
+  // legacy providers, and read paths must preserve them instead of crashing.
   provider: z.string(),
   model_id: z.string(),
   capabilities: z.array(z.string()),

--- a/src/types/agent.ts
+++ b/src/types/agent.ts
@@ -3,43 +3,46 @@ import { z } from "zod";
 export const AgentStatus = z.enum(["active", "degraded", "disabled"]);
 export type AgentStatus = z.infer<typeof AgentStatus>;
 
+export const AgentProvider = z.enum(["anthropic", "openai", "local"]);
+export type AgentProvider = z.infer<typeof AgentProvider>;
+
 export const AgentRegistration = z.object({
   agent_id: z.string(),
-  provider: z.string(),
+  provider: AgentProvider,
   model_id: z.string(),
   capabilities: z.array(z.string()),
-  cost_per_1k_input: z.number(),
-  cost_per_1k_output: z.number(),
-  max_context_tokens: z.number(),
-  avg_latency_ms: z.number(),
+  cost_per_1k_input: z.number().min(0),
+  cost_per_1k_output: z.number().min(0),
+  max_context_tokens: z.number().int().positive(),
+  avg_latency_ms: z.number().int().min(0),
   status: AgentStatus,
-  tier_ceiling: z.number(),
+  tier_ceiling: z.number().int().min(1).max(4),
 });
 export type AgentRegistration = z.infer<typeof AgentRegistration>;
 
 export const CreateAgentInput = z.object({
   agent_id: z.string(),
-  provider: z.string(),
+  provider: AgentProvider,
   model_id: z.string(),
   capabilities: z.array(z.string()),
-  cost_per_1k_input: z.number(),
-  cost_per_1k_output: z.number(),
-  max_context_tokens: z.number(),
-  avg_latency_ms: z.number().default(0),
+  cost_per_1k_input: z.number().min(0),
+  cost_per_1k_output: z.number().min(0),
+  max_context_tokens: z.number().int().positive(),
+  avg_latency_ms: z.number().int().min(0).default(0),
   status: AgentStatus.default("active"),
-  tier_ceiling: z.number(),
+  tier_ceiling: z.number().int().min(1).max(4),
 });
 export type CreateAgentInput = z.infer<typeof CreateAgentInput>;
 
 export const UpdateAgentInput = z.object({
-  provider: z.string().optional(),
+  provider: AgentProvider.optional(),
   model_id: z.string().optional(),
   capabilities: z.array(z.string()).optional(),
-  cost_per_1k_input: z.number().optional(),
-  cost_per_1k_output: z.number().optional(),
-  max_context_tokens: z.number().optional(),
-  avg_latency_ms: z.number().optional(),
+  cost_per_1k_input: z.number().min(0).optional(),
+  cost_per_1k_output: z.number().min(0).optional(),
+  max_context_tokens: z.number().int().positive().optional(),
+  avg_latency_ms: z.number().int().min(0).optional(),
   status: AgentStatus.optional(),
-  tier_ceiling: z.number().optional(),
+  tier_ceiling: z.number().int().min(1).max(4).optional(),
 });
 export type UpdateAgentInput = z.infer<typeof UpdateAgentInput>;

--- a/src/types/agent.ts
+++ b/src/types/agent.ts
@@ -16,7 +16,9 @@ export const AgentRegistration = z.object({
   cost_per_1k_input: z.number().min(0),
   cost_per_1k_output: z.number().min(0),
   max_context_tokens: z.number().int().positive(),
-  avg_latency_ms: z.number().int().min(0),
+  // Output/read schema is intentionally tolerant of fractional computed
+  // latencies from future aggregate reads; create/update inputs remain ints.
+  avg_latency_ms: z.number().min(0),
   status: AgentStatus,
   tier_ceiling: z.number().int().min(1).max(4),
 });

--- a/src/types/agent.ts
+++ b/src/types/agent.ts
@@ -8,7 +8,7 @@ export type AgentProvider = z.infer<typeof AgentProvider>;
 
 export const AgentRegistration = z.object({
   agent_id: z.string(),
-  provider: AgentProvider,
+  provider: z.string(),
   model_id: z.string(),
   capabilities: z.array(z.string()),
   cost_per_1k_input: z.number().min(0),

--- a/src/types/router.ts
+++ b/src/types/router.ts
@@ -25,7 +25,7 @@ export const RouterTaskInput = z.object({
     .object({
       max_tokens: z.number().int().min(1).max(8192).optional(),
       timeout_ms: z.number().int().min(1_000).max(120_000).optional(),
-      temperature: z.number().min(0).max(2).optional(),
+      temperature: z.number().min(0).max(1).optional(),
     })
     .optional(),
   expected_format: FormatSpec.optional(),

--- a/src/types/router.ts
+++ b/src/types/router.ts
@@ -23,9 +23,9 @@ export const RouterTaskInput = z.object({
     .optional(),
   constraints: z
     .object({
-      max_tokens: z.number().optional(),
-      timeout_ms: z.number().optional(),
-      temperature: z.number().optional(),
+      max_tokens: z.number().int().min(1).max(8192).optional(),
+      timeout_ms: z.number().int().min(1_000).max(120_000).optional(),
+      temperature: z.number().min(0).max(2).optional(),
     })
     .optional(),
   expected_format: FormatSpec.optional(),

--- a/tests/api/agents-body-unit.test.ts
+++ b/tests/api/agents-body-unit.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const createAgentMock = vi.fn();
+const updateAgentMock = vi.fn();
+const deleteAgentMock = vi.fn();
+const getAgentMock = vi.fn();
+const listAgentsMock = vi.fn();
+
+vi.mock("../../src/services/agent-registry.js", () => ({
+  createAgent: (...args: unknown[]) => createAgentMock(...args),
+  updateAgent: (...args: unknown[]) => updateAgentMock(...args),
+  deleteAgent: (...args: unknown[]) => deleteAgentMock(...args),
+  getAgent: (...args: unknown[]) => getAgentMock(...args),
+  listAgents: (...args: unknown[]) => listAgentsMock(...args),
+}));
+
+import { createApp } from "../../src/api/app.js";
+
+describe("agent API request body handling", () => {
+  beforeEach(() => {
+    createAgentMock.mockReset();
+    updateAgentMock.mockReset();
+    deleteAgentMock.mockReset();
+    getAgentMock.mockReset();
+    listAgentsMock.mockReset();
+  });
+
+  it("returns 400 for malformed JSON on POST /agents", async () => {
+    const app = createApp();
+
+    const res = await app.request("/v1/agents", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "{bad",
+    });
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "Invalid JSON request body" });
+    expect(createAgentMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for malformed JSON on PUT /agents/:id", async () => {
+    const app = createApp();
+
+    const res = await app.request("/v1/agents/agent-1", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: "{bad",
+    });
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "Invalid JSON request body" });
+    expect(getAgentMock).not.toHaveBeenCalled();
+    expect(updateAgentMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when updating an agent to unknown capabilities", async () => {
+    getAgentMock.mockResolvedValue({
+      agent_id: "agent-1",
+      provider: "local",
+      model_id: "test",
+      capabilities: ["summarization"],
+      cost_per_1k_input: 0,
+      cost_per_1k_output: 0,
+      max_context_tokens: 4096,
+      avg_latency_ms: 100,
+      status: "active",
+      tier_ceiling: 1,
+    });
+    updateAgentMock.mockRejectedValue(new Error("Unknown capabilities: fake_capability"));
+    const app = createApp();
+
+    const res = await app.request("/v1/agents/agent-1", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ capabilities: ["fake_capability"] }),
+    });
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "Unknown capabilities: fake_capability" });
+  });
+});

--- a/tests/api/agents-body-unit.test.ts
+++ b/tests/api/agents-body-unit.test.ts
@@ -1,10 +1,29 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 
-const createAgentMock = vi.fn();
-const updateAgentMock = vi.fn();
-const deleteAgentMock = vi.fn();
-const getAgentMock = vi.fn();
-const listAgentsMock = vi.fn();
+const {
+  createAgentMock,
+  updateAgentMock,
+  deleteAgentMock,
+  getAgentMock,
+  listAgentsMock,
+  MockCapabilityValidationError,
+} = vi.hoisted(() => {
+  class MockCapabilityValidationError extends Error {
+    constructor(message: string) {
+      super(message);
+      this.name = "CapabilityValidationError";
+    }
+  }
+
+  return {
+    createAgentMock: vi.fn(),
+    updateAgentMock: vi.fn(),
+    deleteAgentMock: vi.fn(),
+    getAgentMock: vi.fn(),
+    listAgentsMock: vi.fn(),
+    MockCapabilityValidationError,
+  };
+});
 
 vi.mock("../../src/services/agent-registry.js", () => ({
   createAgent: (...args: unknown[]) => createAgentMock(...args),
@@ -12,6 +31,7 @@ vi.mock("../../src/services/agent-registry.js", () => ({
   deleteAgent: (...args: unknown[]) => deleteAgentMock(...args),
   getAgent: (...args: unknown[]) => getAgentMock(...args),
   listAgents: (...args: unknown[]) => listAgentsMock(...args),
+  CapabilityValidationError: MockCapabilityValidationError,
 }));
 
 import { createApp } from "../../src/api/app.js";
@@ -54,6 +74,31 @@ describe("agent API request body handling", () => {
     expect(updateAgentMock).not.toHaveBeenCalled();
   });
 
+  it("returns 400 when creating an agent with unknown capabilities", async () => {
+    createAgentMock.mockRejectedValue(
+      new MockCapabilityValidationError("Unknown capabilities: fake_capability"),
+    );
+    const app = createApp();
+
+    const res = await app.request("/v1/agents", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        agent_id: "agent-1",
+        provider: "local",
+        model_id: "test",
+        capabilities: ["fake_capability"],
+        cost_per_1k_input: 0,
+        cost_per_1k_output: 0,
+        max_context_tokens: 4096,
+        tier_ceiling: 1,
+      }),
+    });
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "Unknown capabilities: fake_capability" });
+  });
+
   it("returns 400 when updating an agent to unknown capabilities", async () => {
     getAgentMock.mockResolvedValue({
       agent_id: "agent-1",
@@ -67,7 +112,9 @@ describe("agent API request body handling", () => {
       status: "active",
       tier_ceiling: 1,
     });
-    updateAgentMock.mockRejectedValue(new Error("Unknown capabilities: fake_capability"));
+    updateAgentMock.mockRejectedValue(
+      new MockCapabilityValidationError("Unknown capabilities: fake_capability"),
+    );
     const app = createApp();
 
     const res = await app.request("/v1/agents/agent-1", {

--- a/tests/api/demo.test.ts
+++ b/tests/api/demo.test.ts
@@ -103,7 +103,7 @@ describe("/demo gating", () => {
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
         prompt: "hello",
-        constraints: { max_tokens: 100_000, timeout_ms: 600_000, temperature: 0.5 },
+        constraints: { max_tokens: 8192, timeout_ms: 120_000, temperature: 0.5 },
       }),
     });
 
@@ -116,6 +116,25 @@ describe("/demo gating", () => {
     expect(passedInput.constraints.timeout_ms).toBe(15_000);
     // Non-clamped fields pass through untouched.
     expect(passedInput.constraints.temperature).toBe(0.5);
+  });
+
+  it("returns 400 for malformed JSON", async () => {
+    process.env.HAOL_ENABLE_DEMO = "1";
+    buildSuccessfulRouterResponse();
+    const app = createApp();
+
+    const res = await app.request("/demo/api/task", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "{bad",
+    });
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({
+      error: "Invalid JSON request body",
+      details: undefined,
+    });
+    expect(routeTaskMock).not.toHaveBeenCalled();
   });
 
   it("applies the clamps even when caller omits constraints entirely", async () => {

--- a/tests/api/demo.test.ts
+++ b/tests/api/demo.test.ts
@@ -130,10 +130,7 @@ describe("/demo gating", () => {
     });
 
     expect(res.status).toBe(400);
-    expect(await res.json()).toEqual({
-      error: "Invalid JSON request body",
-      details: undefined,
-    });
+    expect(await res.json()).toEqual({ error: "Invalid JSON request body" });
     expect(routeTaskMock).not.toHaveBeenCalled();
   });
 

--- a/tests/api/outcomes-body-unit.test.ts
+++ b/tests/api/outcomes-body-unit.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect, vi } from "vitest";
+
+const recordDownstreamOutcomeMock = vi.fn();
+
+vi.mock("../../src/services/outcome-collector.js", () => ({
+  recordDownstreamOutcome: (...args: unknown[]) => recordDownstreamOutcomeMock(...args),
+}));
+
+vi.mock("../../src/repositories/task-outcome.js", () => ({
+  findByTaskId: vi.fn(),
+  findByTaskIdAndTier: vi.fn(),
+}));
+
+vi.mock("../../src/repositories/task-log.js", () => ({
+  findById: vi.fn(),
+}));
+
+import { createApp } from "../../src/api/app.js";
+
+describe("POST /tasks/:id/outcome body parsing", () => {
+  it("returns 400 for malformed JSON before recording an outcome", async () => {
+    const app = createApp();
+
+    const res = await app.request("/v1/tasks/task-1/outcome", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "{bad",
+    });
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "Invalid JSON request body" });
+    expect(recordDownstreamOutcomeMock).not.toHaveBeenCalled();
+  });
+});

--- a/tests/api/tasks-intake-unit.test.ts
+++ b/tests/api/tasks-intake-unit.test.ts
@@ -67,6 +67,40 @@ describe("POST /tasks intake failure handling", () => {
     expect(recordWorkerErrorMock).toHaveBeenCalledWith(body.task_id, "enqueue_failed:queue_full");
   });
 
+  it("returns 503 for non-capacity enqueue failures", async () => {
+    enqueueMock.mockReturnValue("stopping");
+    const app = createApp();
+
+    const res = await app.request("/v1/tasks", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ prompt: "summarize this" }),
+    });
+    const body = (await res.json()) as { task_id: string; status: string };
+
+    expect(res.status).toBe(503);
+    expect(body.status).toBe("FAILED");
+    expect(recordWorkerErrorMock).toHaveBeenCalledWith(body.task_id, "enqueue_failed:stopping");
+  });
+
+  it("still returns retry guidance if marking the enqueue failure fails", async () => {
+    enqueueMock.mockReturnValue("stopping");
+    recordWorkerErrorMock.mockRejectedValue(new Error("db unavailable"));
+    const app = createApp();
+
+    const res = await app.request("/v1/tasks", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ prompt: "summarize this" }),
+    });
+    const body = (await res.json()) as { task_id: string; status: string };
+
+    expect(res.status).toBe(503);
+    expect(res.headers.get("Retry-After")).toBe("5");
+    expect(body.task_id).toBeTruthy();
+    expect(body.status).toBe("FAILED");
+  });
+
   it("returns 400 for malformed JSON before touching intake state", async () => {
     const app = createApp();
 

--- a/tests/api/tasks-intake-unit.test.ts
+++ b/tests/api/tasks-intake-unit.test.ts
@@ -59,7 +59,7 @@ describe("POST /tasks intake failure handling", () => {
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ prompt: "summarize this" }),
     });
-    const body = (await res.json()) as { task_id: string; status: string };
+    const body = (await res.json()) as { task_id: string; status: string; warning?: string };
 
     expect(res.status).toBe(429);
     expect(res.headers.get("Retry-After")).toBe("5");
@@ -102,6 +102,9 @@ describe("POST /tasks intake failure handling", () => {
     expect(res.headers.get("Retry-After")).toBeNull();
     expect(body.task_id).toBeTruthy();
     expect(body.status).toBe("QUEUED");
+    expect(body.warning).toBe(
+      "task row remains queued and may execute later; poll task_id before retrying",
+    );
   });
 
   it("returns 400 for malformed JSON before touching intake state", async () => {

--- a/tests/api/tasks-intake-unit.test.ts
+++ b/tests/api/tasks-intake-unit.test.ts
@@ -61,6 +61,7 @@ describe("POST /tasks intake failure handling", () => {
     const body = (await res.json()) as { task_id: string; status: string };
 
     expect(res.status).toBe(429);
+    expect(res.headers.get("Retry-After")).toBe("5");
     expect(body.task_id).toBeTruthy();
     expect(body.status).toBe("FAILED");
     expect(createQueuedMock).toHaveBeenCalledTimes(1);
@@ -79,11 +80,12 @@ describe("POST /tasks intake failure handling", () => {
     const body = (await res.json()) as { task_id: string; status: string };
 
     expect(res.status).toBe(503);
+    expect(res.headers.get("Retry-After")).toBeNull();
     expect(body.status).toBe("FAILED");
     expect(recordWorkerErrorMock).toHaveBeenCalledWith(body.task_id, "enqueue_failed:stopping");
   });
 
-  it("still returns retry guidance if marking the enqueue failure fails", async () => {
+  it("still returns a 503 if marking the enqueue failure fails", async () => {
     enqueueMock.mockReturnValue("stopping");
     recordWorkerErrorMock.mockRejectedValue(new Error("db unavailable"));
     const app = createApp();
@@ -96,7 +98,7 @@ describe("POST /tasks intake failure handling", () => {
     const body = (await res.json()) as { task_id: string; status: string };
 
     expect(res.status).toBe(503);
-    expect(res.headers.get("Retry-After")).toBe("5");
+    expect(res.headers.get("Retry-After")).toBeNull();
     expect(body.task_id).toBeTruthy();
     expect(body.status).toBe("FAILED");
   });

--- a/tests/api/tasks-intake-unit.test.ts
+++ b/tests/api/tasks-intake-unit.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const createQueuedMock = vi.fn();
+const recordWorkerErrorMock = vi.fn();
+const canAcceptMock = vi.fn();
+const enqueueMock = vi.fn();
+
+vi.mock("../../src/repositories/task-log.js", () => ({
+  createQueued: (...args: unknown[]) => createQueuedMock(...args),
+  recordWorkerError: (...args: unknown[]) => recordWorkerErrorMock(...args),
+  findById: vi.fn(),
+}));
+
+vi.mock("../../src/repositories/execution-log.js", () => ({
+  findByTaskId: vi.fn(),
+}));
+
+vi.mock("../../src/cascade-router/reference-store.js", () => ({
+  findTraceByTaskId: vi.fn(),
+}));
+
+vi.mock("../../src/services/task-worker.js", () => ({
+  canAccept: (...args: unknown[]) => canAcceptMock(...args),
+  enqueue: (...args: unknown[]) => enqueueMock(...args),
+}));
+
+import { createApp } from "../../src/api/app.js";
+
+describe("POST /tasks intake failure handling", () => {
+  beforeEach(() => {
+    createQueuedMock.mockReset().mockResolvedValue(undefined);
+    recordWorkerErrorMock.mockReset().mockResolvedValue(undefined);
+    canAcceptMock.mockReset().mockReturnValue(true);
+    enqueueMock.mockReset().mockReturnValue("ok");
+  });
+
+  it("returns 429 before inserting when the worker queue is saturated", async () => {
+    canAcceptMock.mockReturnValue(false);
+    const app = createApp();
+
+    const res = await app.request("/v1/tasks", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ prompt: "summarize this" }),
+    });
+
+    expect(res.status).toBe(429);
+    expect(createQueuedMock).not.toHaveBeenCalled();
+    expect(enqueueMock).not.toHaveBeenCalled();
+  });
+
+  it("marks the inserted row failed if enqueue loses the post-insert race", async () => {
+    enqueueMock.mockReturnValue("queue_full");
+    const app = createApp();
+
+    const res = await app.request("/v1/tasks", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ prompt: "summarize this" }),
+    });
+    const body = (await res.json()) as { task_id: string; status: string };
+
+    expect(res.status).toBe(429);
+    expect(body.task_id).toBeTruthy();
+    expect(body.status).toBe("FAILED");
+    expect(createQueuedMock).toHaveBeenCalledTimes(1);
+    expect(recordWorkerErrorMock).toHaveBeenCalledWith(body.task_id, "enqueue_failed:queue_full");
+  });
+
+  it("returns 400 for malformed JSON before touching intake state", async () => {
+    const app = createApp();
+
+    const res = await app.request("/v1/tasks", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "{bad",
+    });
+
+    expect(res.status).toBe(400);
+    expect(createQueuedMock).not.toHaveBeenCalled();
+    expect(enqueueMock).not.toHaveBeenCalled();
+  });
+});

--- a/tests/api/tasks-intake-unit.test.ts
+++ b/tests/api/tasks-intake-unit.test.ts
@@ -117,6 +117,7 @@ describe("POST /tasks intake failure handling", () => {
     });
 
     expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "Invalid JSON request body" });
     expect(createQueuedMock).not.toHaveBeenCalled();
     expect(enqueueMock).not.toHaveBeenCalled();
   });

--- a/tests/api/tasks-intake-unit.test.ts
+++ b/tests/api/tasks-intake-unit.test.ts
@@ -101,7 +101,7 @@ describe("POST /tasks intake failure handling", () => {
     expect(res.status).toBe(503);
     expect(res.headers.get("Retry-After")).toBeNull();
     expect(body.task_id).toBeTruthy();
-    expect(body.status).toBe("FAILED");
+    expect(body.status).toBe("QUEUED");
   });
 
   it("returns 400 for malformed JSON before touching intake state", async () => {

--- a/tests/api/tasks-intake-unit.test.ts
+++ b/tests/api/tasks-intake-unit.test.ts
@@ -45,6 +45,7 @@ describe("POST /tasks intake failure handling", () => {
     });
 
     expect(res.status).toBe(429);
+    expect(res.headers.get("Retry-After")).toBe("5");
     expect(createQueuedMock).not.toHaveBeenCalled();
     expect(enqueueMock).not.toHaveBeenCalled();
   });

--- a/tests/repositories/agent-registry.test.ts
+++ b/tests/repositories/agent-registry.test.ts
@@ -49,6 +49,24 @@ afterAll(async () => {
 });
 
 describe("agent-registry repository", () => {
+  it("parseAgentRow preserves unknown legacy providers instead of throwing", () => {
+    const parsed = repo.parseAgentRow({
+      agent_id: "legacy-agent",
+      provider: "legacy-provider",
+      model_id: "legacy-model",
+      capabilities: '["summarization"]',
+      cost_per_1k_input: "0.001000",
+      cost_per_1k_output: "0.002000",
+      max_context_tokens: 4096,
+      avg_latency_ms: 250,
+      status: "active",
+      tier_ceiling: 2,
+    } as any);
+
+    expect(parsed.provider).toBe("legacy-provider");
+    expect(parsed.agent_id).toBe("legacy-agent");
+  });
+
   it("create + findById round-trip", async ({ skip }) => {
     if (!doltAvailable) skip();
 

--- a/tests/repositories/agent-registry.test.ts
+++ b/tests/repositories/agent-registry.test.ts
@@ -11,7 +11,7 @@ const testPrefix = `test-repo-${Date.now()}`;
 function makeAgent(suffix: string, overrides?: Partial<CreateAgentInput>): CreateAgentInput {
   return {
     agent_id: `${testPrefix}-${suffix}`,
-    provider: "test-provider",
+    provider: "local",
     model_id: "test-model-v1",
     capabilities: ["summarization", "classification"],
     cost_per_1k_input: 0.001,
@@ -58,7 +58,7 @@ describe("agent-registry repository", () => {
     const found = await repo.findById(input.agent_id);
     expect(found).not.toBeNull();
     expect(found!.agent_id).toBe(input.agent_id);
-    expect(found!.provider).toBe("test-provider");
+    expect(found!.provider).toBe("local");
     expect(found!.capabilities).toEqual(["summarization", "classification"]);
     expect(typeof found!.cost_per_1k_input).toBe("number");
     expect(found!.cost_per_1k_input).toBeCloseTo(0.001, 5);
@@ -119,7 +119,7 @@ describe("agent-registry repository", () => {
     expect(updated!.avg_latency_ms).toBe(999);
     expect(updated!.status).toBe("degraded");
     // Unchanged fields should remain
-    expect(updated!.provider).toBe("test-provider");
+    expect(updated!.provider).toBe("local");
   });
 
   it("remove sets status to disabled", async ({ skip }) => {

--- a/tests/services/agent-registry.test.ts
+++ b/tests/services/agent-registry.test.ts
@@ -11,7 +11,7 @@ const testPrefix = `test-svc-${Date.now()}`;
 function makeAgent(suffix: string, overrides?: Partial<CreateAgentInput>): CreateAgentInput {
   return {
     agent_id: `${testPrefix}-${suffix}`,
-    provider: "test-provider",
+    provider: "local",
     model_id: "test-model-v1",
     capabilities: ["summarization", "classification"],
     cost_per_1k_input: 0.001,

--- a/tests/services/agent-selection.test.ts
+++ b/tests/services/agent-selection.test.ts
@@ -432,8 +432,8 @@ describe("agent-selection service", () => {
     // Insert two agents with identical stats but different IDs
     await getPool().query(
       `INSERT IGNORE INTO agent_registry (agent_id, provider, model_id, capabilities, cost_per_1k_input, cost_per_1k_output, max_context_tokens, avg_latency_ms, status, tier_ceiling) VALUES
-        ('sel-tie-alpha', 'test', 'tie', '["tiebreak_test"]', 0.001000, 0.002000, 100000, 500, 'active', 2),
-        ('sel-tie-beta', 'test', 'tie', '["tiebreak_test"]', 0.001000, 0.002000, 100000, 500, 'active', 2)`,
+        ('sel-tie-alpha', 'local', 'tie', '["tiebreak_test"]', 0.001000, 0.002000, 100000, 500, 'active', 2),
+        ('sel-tie-beta', 'local', 'tie', '["tiebreak_test"]', 0.001000, 0.002000, 100000, 500, 'active', 2)`,
     );
 
     const classification: TaskClassification = {

--- a/tests/services/routing-tuner.test.ts
+++ b/tests/services/routing-tuner.test.ts
@@ -168,7 +168,7 @@ describe("aggregateOutcomesByAgentTier", () => {
 
     await pool.query(
       `INSERT IGNORE INTO agent_registry (agent_id, provider, model_id, capabilities, cost_per_1k_input, cost_per_1k_output, max_context_tokens, avg_latency_ms, status, tier_ceiling)
-       VALUES (?, 'test', 'test-model', '["code"]', 0.01, 0.02, 4096, 500, 'active', 4)`,
+       VALUES (?, 'local', 'test-model', '["code"]', 0.01, 0.02, 4096, 500, 'active', 4)`,
       [agentId],
     );
     await pool.query(

--- a/tests/types/agent.test.ts
+++ b/tests/types/agent.test.ts
@@ -69,6 +69,38 @@ describe("CreateAgentInput schema", () => {
       }),
     ).toThrow();
   });
+
+  it("fails with an unsupported provider", () => {
+    expect(() =>
+      CreateAgentInput.parse({
+        ...validInput,
+        provider: "unknown-provider",
+      }),
+    ).toThrow();
+  });
+
+  it("rejects invalid numeric bounds", () => {
+    expect(() =>
+      CreateAgentInput.parse({
+        ...validInput,
+        cost_per_1k_input: -1,
+      }),
+    ).toThrow();
+
+    expect(() =>
+      CreateAgentInput.parse({
+        ...validInput,
+        max_context_tokens: 0,
+      }),
+    ).toThrow();
+
+    expect(() =>
+      CreateAgentInput.parse({
+        ...validInput,
+        tier_ceiling: 5,
+      }),
+    ).toThrow();
+  });
 });
 
 describe("UpdateAgentInput schema", () => {
@@ -80,6 +112,10 @@ describe("UpdateAgentInput schema", () => {
   it("allows partial updates", () => {
     const result = UpdateAgentInput.parse({ status: "degraded" });
     expect(result.status).toBe("degraded");
+  });
+
+  it("rejects unsupported provider updates", () => {
+    expect(() => UpdateAgentInput.parse({ provider: "unsupported" })).toThrow();
   });
 });
 

--- a/tests/types/router.test.ts
+++ b/tests/types/router.test.ts
@@ -33,7 +33,7 @@ describe("RouterTaskInput constraints", () => {
     expect(
       RouterTaskInput.safeParse({
         prompt: "summarize this",
-        constraints: { temperature: 99 },
+        constraints: { temperature: 1.5 },
       }).success,
     ).toBe(false);
   });

--- a/tests/types/router.test.ts
+++ b/tests/types/router.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "vitest";
+import { RouterTaskInput } from "../../src/types/router.js";
+
+describe("RouterTaskInput constraints", () => {
+  it("accepts bounded execution constraints", () => {
+    const result = RouterTaskInput.safeParse({
+      prompt: "summarize this",
+      constraints: {
+        max_tokens: 1024,
+        timeout_ms: 15_000,
+        temperature: 0.5,
+      },
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects unbounded token, timeout, and temperature values", () => {
+    expect(
+      RouterTaskInput.safeParse({
+        prompt: "summarize this",
+        constraints: { max_tokens: 100_000 },
+      }).success,
+    ).toBe(false);
+
+    expect(
+      RouterTaskInput.safeParse({
+        prompt: "summarize this",
+        constraints: { timeout_ms: 600_000 },
+      }).success,
+    ).toBe(false);
+
+    expect(
+      RouterTaskInput.safeParse({
+        prompt: "summarize this",
+        constraints: { temperature: 99 },
+      }).success,
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- return 400 for malformed JSON request bodies across task, agent, outcome, and demo endpoints
- prevent hidden queued task execution after post-insert enqueue failures, including best-effort failure marking
- bound task execution constraints and tighten agent create/update validation
- preserve legacy rows with unrecognized providers on read while logging a warning

## Breaking API changes
- pre-insert task queue saturation now returns 429 instead of 503, with Retry-After: 5
- task requests with constraints.max_tokens above 8192 now fail validation with 400 instead of being accepted
- task requests with constraints.temperature above 1.0 now fail validation with 400 to stay within the common provider-safe range
- task requests with constraints.timeout_ms outside [1000, 120000] now fail validation with 400 instead of being accepted

## Validation
- npm run build
- npm run format:check
- npx vitest run --testTimeout=5000