### PR TITLE
Fix #16: page findQueued to avoid boot-time OOM

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,6 +29,10 @@ WORKER_MAX_QUEUE_DEPTH=1000
 WORKER_RECOVERY_AGE_MS=600000
 # Reaper sweep cadence in ms. Default 60000 (1 min).
 WORKER_REAPER_INTERVAL_MS=60000
+# Page size for the reaper's startup re-enqueue of QUEUED rows. Bounds peak
+# memory (each row carries its prompt) without making the sweep chatty.
+# Default 100.
+WORKER_REQUEUE_PAGE_SIZE=100
 
 # Memory layer
 # Per-task Dolt session branches are kept on disk for this many days after

--- a/src/repositories/task-log.ts
+++ b/src/repositories/task-log.ts
@@ -5,7 +5,8 @@ import type { TaskStatus } from "../types/router.js";
 
 interface TaskLogRow extends RowDataPacket {
   task_id: string;
-  created_at: string;
+  // mysql2 deserialises TIMESTAMP as a JS Date (no dateStrings on the pool).
+  created_at: string | Date;
   status: string;
   prompt_hash: string | null;
   prompt: string | null;
@@ -27,7 +28,9 @@ interface TaskLogRow extends RowDataPacket {
 
 export interface TaskLogRecord {
   task_id: string;
-  created_at: string;
+  // Date at runtime (mysql2 deserialises TIMESTAMP without dateStrings); typed
+  // as the union so consumers that page on it (see QueuedCursor) are honest.
+  created_at: string | Date;
   status: TaskStatus;
   prompt_hash: string | null;
   prompt: string | null;
@@ -236,7 +239,7 @@ interface StaleTaskRow extends RowDataPacket {
 /**
  * Reaper query: find rows that have been sitting in non-terminal in-flight
  * states longer than maxAgeSeconds. QUEUED is excluded — it's handled
- * separately by findQueued() since it's safe to retry.
+ * separately by findQueuedPage() since it's safe to retry.
  *
  * Age is measured from worker pickup (`worker_started_at`), not intake
  * (`created_at`). A row that sat in QUEUED for an hour before a worker
@@ -260,12 +263,53 @@ export async function findStale(maxAgeSeconds: number): Promise<string[]> {
 }
 
 /**
- * Returns all currently-QUEUED rows. Used at startup to re-enqueue tasks
- * that arrived while the worker was down.
+ * Keyset cursor for paging through QUEUED rows in (created_at, task_id) order.
+ * `created_at` matches TaskLogRecord.created_at (a Date at runtime) and is bound
+ * through unchanged. task_log.created_at is whole-second precision, so the Date
+ * round-trips to the exact stored value when mysql2 re-serializes it for the
+ * bound parameter.
  */
-export async function findQueued(): Promise<TaskLogRecord[]> {
+export interface QueuedCursor {
+  created_at: string | Date;
+  task_id: string;
+}
+
+/**
+ * Returns one page of currently-QUEUED rows ordered by (created_at, task_id)
+ * ascending. Used at startup to re-enqueue tasks that arrived while the worker
+ * was down.
+ *
+ * Paged (keyset, not OFFSET) so the reaper never loads the entire backlog —
+ * including every row's `prompt` LONGTEXT — into memory at once. A boot-time
+ * surge of large prompts would otherwise risk OOM. The reaper must still pull
+ * the prompt/metadata columns (it reconstructs the full job to re-enqueue), so
+ * the protection is bounding the *page*, not dropping columns.
+ *
+ * The (created_at, task_id) tuple is unique (task_id is the PK), so the keyset
+ * predicate never skips or repeats a row even when many tasks share a
+ * created_at. The `idx_task_log_status_created (status, created_at)` index
+ * from migration 019 supports the WHERE+ORDER BY prefix.
+ *
+ * Pass the last row of the previous page as `after` to fetch the next page;
+ * a page shorter than `limit` means the queue is drained.
+ */
+export async function findQueuedPage(
+  limit: number,
+  after?: QueuedCursor,
+): Promise<TaskLogRecord[]> {
+  const params: (string | number | Date)[] = [];
+  let cursorClause = "";
+  if (after) {
+    cursorClause = "AND (created_at > ? OR (created_at = ? AND task_id > ?))";
+    params.push(after.created_at, after.created_at, after.task_id);
+  }
+  params.push(limit);
   const rows = await query<TaskLogRow[]>(
-    `SELECT * FROM task_log WHERE status = 'QUEUED' ORDER BY created_at ASC`,
+    `SELECT * FROM task_log
+       WHERE status = 'QUEUED' ${cursorClause}
+       ORDER BY created_at ASC, task_id ASC
+       LIMIT ?`,
+    params,
   );
   return rows.map(parseRow);
 }

--- a/src/services/task-reaper.ts
+++ b/src/services/task-reaper.ts
@@ -26,6 +26,16 @@ import { runWithContext } from "../logging/context.js";
 
 const STUCK_REASON = "worker_crashed";
 
+// How many QUEUED rows to pull per page when re-enqueuing at startup. Bounds
+// peak memory (each row carries its LONGTEXT prompt) without making the sweep
+// chatty. Override via WORKER_REQUEUE_PAGE_SIZE.
+function queuedPageSize(): number {
+  const raw = process.env.WORKER_REQUEUE_PAGE_SIZE;
+  if (!raw) return 100;
+  const n = parseInt(raw, 10);
+  return Number.isFinite(n) && n > 0 ? n : 100;
+}
+
 let timer: NodeJS.Timeout | null = null;
 
 // Floor the recovery threshold at 5 min so a misconfigured value can't
@@ -97,26 +107,53 @@ async function runReaperOnceInner(): Promise<{
   // empty at startup, so anything that survived a restart needs a kick. At
   // steady state during periodic sweeps, claimQueued() will harmlessly
   // refuse duplicates.
-  let queued: taskLog.TaskLogRecord[] = [];
-  try {
-    queued = await taskLog.findQueued();
-  } catch (err) {
-    logger.warn("findQueued failed", { error: (err as Error).message });
-  }
-  for (const row of queued) {
-    const input = reconstructInput(row);
-    if (!input) {
-      // Row predates the async pipeline (no stashed prompt); fail it.
-      try {
-        await taskLog.recordWorkerError(row.task_id, "queued_without_prompt");
-        failed++;
-      } catch {
-        // best-effort
-      }
-      continue;
+  //
+  // Drained page-by-page (keyset on created_at, task_id) rather than loading
+  // every QUEUED row — including its LONGTEXT prompt — at once: a boot-time
+  // backlog of large prompts would otherwise risk OOM. We stop early once the
+  // worker can't accept more, so we don't pull prompts the worker would just
+  // reject (its in-memory queue cap converts overflow into queue_full anyway).
+  const pageSize = queuedPageSize();
+  let cursor: taskLog.QueuedCursor | undefined;
+  let draining = true;
+  while (draining) {
+    let page: taskLog.TaskLogRecord[] = [];
+    try {
+      page = await taskLog.findQueuedPage(pageSize, cursor);
+    } catch (err) {
+      logger.warn("findQueuedPage failed", { error: (err as Error).message });
+      break;
     }
-    worker.enqueue(row.task_id, input);
-    reEnqueued++;
+    if (page.length === 0) break;
+
+    for (const row of page) {
+      const input = reconstructInput(row);
+      if (!input) {
+        // Row predates the async pipeline (no stashed prompt); fail it.
+        try {
+          await taskLog.recordWorkerError(row.task_id, "queued_without_prompt");
+          failed++;
+        } catch {
+          // best-effort
+        }
+        continue;
+      }
+      if (!worker.canAccept()) {
+        // Worker queue is full/stopping — leave the rest QUEUED for the next
+        // sweep instead of loading more prompts it can't take.
+        draining = false;
+        break;
+      }
+      worker.enqueue(row.task_id, input);
+      reEnqueued++;
+    }
+
+    // Stop on a short page (queue drained) or an early stop (worker full).
+    // Only advance the cursor when we'll actually fetch another page, so we
+    // never leave a cursor pointing past unprocessed rows.
+    if (!draining || page.length < pageSize) break;
+    const last = page[page.length - 1];
+    cursor = { created_at: last.created_at, task_id: last.task_id };
   }
 
   // 2. Mark stale in-flight rows FAILED. findStale returns just the

--- a/tests/services/task-reaper.test.ts
+++ b/tests/services/task-reaper.test.ts
@@ -1,0 +1,198 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import * as taskLog from "../../src/repositories/task-log.js";
+import * as worker from "../../src/services/task-worker.js";
+import * as branchCleanup from "../../src/memory/branch-cleanup.js";
+import { runReaperOnce } from "../../src/services/task-reaper.js";
+
+// --- Unit tests for the QUEUED re-enqueue paging drain (no DB required). ---
+//
+// These mock the repository + worker layers so we can assert the reaper pages
+// through the backlog (keyset cursor) instead of loading every QUEUED row at
+// once (fix #16), advancing the cursor correctly and stopping on a short page.
+
+function makeRecord(
+  taskId: string,
+  createdAt: string,
+  prompt: string | null = "p",
+): taskLog.TaskLogRecord {
+  return {
+    task_id: taskId,
+    created_at: createdAt,
+    status: "QUEUED",
+    prompt_hash: null,
+    prompt,
+    input_metadata: null,
+    input_constraints: null,
+    complexity_tier: null,
+    required_capabilities: null,
+    cost_ceiling_usd: null,
+    selected_agent_id: null,
+    selection_rationale: null,
+    routing_confidence: null,
+    routing_layer: null,
+    expected_format: null,
+    worker_started_at: null,
+    worker_finished_at: null,
+    worker_error: null,
+    response_content: null,
+  };
+}
+
+/** Build a findQueuedPage mock that serves `all` in (created_at, task_id) keyset order. */
+// created_at is `string | Date` at the type level (Date at runtime from mysql2).
+// Coerce to a comparable string so the mock's keyset logic handles both forms,
+// matching how the real SQL orders the column.
+function ts(v: string | Date): string {
+  return v instanceof Date ? v.toISOString() : v;
+}
+
+function pagedSource(all: taskLog.TaskLogRecord[]) {
+  const sorted = [...all].sort((a, b) =>
+    ts(a.created_at) === ts(b.created_at)
+      ? a.task_id.localeCompare(b.task_id)
+      : ts(a.created_at).localeCompare(ts(b.created_at)),
+  );
+  return async (limit: number, after?: taskLog.QueuedCursor): Promise<taskLog.TaskLogRecord[]> => {
+    const start = after
+      ? sorted.findIndex(
+          (r) =>
+            ts(r.created_at) > ts(after.created_at) ||
+            (ts(r.created_at) === ts(after.created_at) && r.task_id > after.task_id),
+        )
+      : 0;
+    if (start === -1) return [];
+    return sorted.slice(start, start + limit);
+  };
+}
+
+function stubNonQueuedWork() {
+  // Isolate the QUEUED re-enqueue path: no stale rows, no branch pruning.
+  vi.spyOn(taskLog, "findStale").mockResolvedValue([]);
+  vi.spyOn(branchCleanup, "pruneSessionBranches").mockResolvedValue([]);
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  delete process.env.WORKER_REQUEUE_PAGE_SIZE;
+});
+
+describe("task-reaper — QUEUED re-enqueue paging", () => {
+  it("pages through the full backlog and re-enqueues every row", async () => {
+    process.env.WORKER_REQUEUE_PAGE_SIZE = "2";
+    stubNonQueuedWork();
+
+    const rows = [
+      makeRecord("a", "2026-06-01 00:00:01"),
+      makeRecord("b", "2026-06-01 00:00:02"),
+      makeRecord("c", "2026-06-01 00:00:03"),
+      makeRecord("d", "2026-06-01 00:00:04"),
+      makeRecord("e", "2026-06-01 00:00:05"),
+    ];
+    const pageSpy = vi.spyOn(taskLog, "findQueuedPage").mockImplementation(pagedSource(rows));
+    vi.spyOn(worker, "canAccept").mockReturnValue(true);
+    const enqueueSpy = vi.spyOn(worker, "enqueue").mockReturnValue("ok");
+
+    const result = await runReaperOnce();
+
+    expect(result.reEnqueued).toBe(5);
+    expect(enqueueSpy.mock.calls.map((c) => c[0])).toEqual(["a", "b", "c", "d", "e"]);
+    // 5 rows / page size 2 => pages of [2,2,1]; the short final page ends the drain.
+    expect(pageSpy).toHaveBeenCalledTimes(3);
+    // Second call must carry the cursor from the last row of page 1 (task "b").
+    expect(pageSpy.mock.calls[1][1]).toEqual({ created_at: "2026-06-01 00:00:02", task_id: "b" });
+  });
+
+  it("stops early without pulling more pages once the worker can't accept", async () => {
+    process.env.WORKER_REQUEUE_PAGE_SIZE = "2";
+    stubNonQueuedWork();
+
+    const rows = [
+      makeRecord("a", "2026-06-01 00:00:01"),
+      makeRecord("b", "2026-06-01 00:00:02"),
+      makeRecord("c", "2026-06-01 00:00:03"),
+      makeRecord("d", "2026-06-01 00:00:04"),
+    ];
+    const pageSpy = vi.spyOn(taskLog, "findQueuedPage").mockImplementation(pagedSource(rows));
+    // Accept the first row, then refuse — the reaper should leave the rest QUEUED.
+    vi.spyOn(worker, "canAccept").mockReturnValueOnce(true).mockReturnValue(false);
+    const enqueueSpy = vi.spyOn(worker, "enqueue").mockReturnValue("ok");
+
+    const result = await runReaperOnce();
+
+    expect(result.reEnqueued).toBe(1);
+    expect(enqueueSpy).toHaveBeenCalledTimes(1);
+    // Only the first page was fetched — no further prompts loaded into memory.
+    expect(pageSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("fails rows that have no stashed prompt instead of enqueuing them", async () => {
+    process.env.WORKER_REQUEUE_PAGE_SIZE = "10";
+    stubNonQueuedWork();
+
+    const rows = [
+      makeRecord("a", "2026-06-01 00:00:01", "real prompt"),
+      makeRecord("b", "2026-06-01 00:00:02", null),
+    ];
+    vi.spyOn(taskLog, "findQueuedPage").mockImplementation(pagedSource(rows));
+    vi.spyOn(worker, "canAccept").mockReturnValue(true);
+    const enqueueSpy = vi.spyOn(worker, "enqueue").mockReturnValue("ok");
+    const errSpy = vi.spyOn(taskLog, "recordWorkerError").mockResolvedValue();
+
+    const result = await runReaperOnce();
+
+    expect(result.reEnqueued).toBe(1);
+    expect(result.failed).toBe(1);
+    expect(enqueueSpy.mock.calls.map((c) => c[0])).toEqual(["a"]);
+    expect(errSpy).toHaveBeenCalledWith("b", "queued_without_prompt");
+  });
+
+  it("advances by task_id when a page boundary splits a same-second group", async () => {
+    process.env.WORKER_REQUEUE_PAGE_SIZE = "2";
+    stubNonQueuedWork();
+
+    // a, b, c all share one second; the page boundary falls between b and c.
+    // Page 2 must resolve via the (created_at = ? AND task_id > ?) tie-break —
+    // a `created_at > ?` predicate alone would skip c (same second as cursor).
+    const rows = [
+      makeRecord("a", "2026-06-01 00:00:01"),
+      makeRecord("b", "2026-06-01 00:00:01"),
+      makeRecord("c", "2026-06-01 00:00:01"),
+      makeRecord("d", "2026-06-01 00:00:02"),
+    ];
+    const pageSpy = vi.spyOn(taskLog, "findQueuedPage").mockImplementation(pagedSource(rows));
+    vi.spyOn(worker, "canAccept").mockReturnValue(true);
+    const enqueueSpy = vi.spyOn(worker, "enqueue").mockReturnValue("ok");
+
+    const result = await runReaperOnce();
+
+    // Every row enqueued exactly once, in order — nothing skipped or repeated.
+    expect(enqueueSpy.mock.calls.map((c) => c[0])).toEqual(["a", "b", "c", "d"]);
+    expect(result.reEnqueued).toBe(4);
+    // The page-2 cursor carries the same-second timestamp + the last task_id.
+    expect(pageSpy.mock.calls[1][1]).toEqual({ created_at: "2026-06-01 00:00:01", task_id: "b" });
+  });
+
+  it("stops draining (and keeps the first page's count) when a later page fails", async () => {
+    process.env.WORKER_REQUEUE_PAGE_SIZE = "2";
+    stubNonQueuedWork();
+
+    // First page returns a full page (so the loop wants another), the second
+    // call throws — the reaper should log and stop, not crash, and the rows
+    // already enqueued from page 1 must still count.
+    const pageSpy = vi
+      .spyOn(taskLog, "findQueuedPage")
+      .mockResolvedValueOnce([
+        makeRecord("a", "2026-06-01 00:00:01"),
+        makeRecord("b", "2026-06-01 00:00:02"),
+      ])
+      .mockRejectedValueOnce(new Error("db gone"));
+    vi.spyOn(worker, "canAccept").mockReturnValue(true);
+    const enqueueSpy = vi.spyOn(worker, "enqueue").mockReturnValue("ok");
+
+    const result = await runReaperOnce();
+
+    expect(result.reEnqueued).toBe(2);
+    expect(enqueueSpy.mock.calls.map((c) => c[0])).toEqual(["a", "b"]);
+    expect(pageSpy).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Issue #16 (High)

`findQueued` did `SELECT *` with no `LIMIT`, so the reaper's startup re-enqueue loaded **every** QUEUED row — including each row's `prompt` LONGTEXT — into memory at once. A boot-time backlog of large prompts risks OOM.

Note: unlike `findStale` (PR #56), columns can't simply be dropped — the reaper's `reconstructInput` needs `prompt`/`input_metadata`/`input_constraints`/`expected_format` to rebuild each job. The fix is **paging**, not column-narrowing.

## Changes
- Replace `findQueued` with `findQueuedPage(limit, after?)`: keyset paging on `(created_at, task_id)`, supported by `idx_task_log_status_created` (migration 019). The tuple is unique (task_id is PK), so the cursor never skips or repeats a row.
- Reaper drains page-by-page and stops early once `worker.canAccept()` is false, so it never loads prompts the worker would reject. Page size via `WORKER_REQUEUE_PAGE_SIZE` (default 100).
- Add Dolt-independent unit tests: cursor advancement, short-page terminator, early stop on a full worker, and missing-prompt rows.

## Testing
`npm run build` clean; `tests/services/task-reaper.test.ts` (3 tests) pass.