### PR TITLE
Fix #11: remove unsafe non-null assertions

### DIFF
--- a/src/cascade-router/cascade-router.ts
+++ b/src/cascade-router/cascade-router.ts
@@ -32,6 +32,21 @@ interface LoadedState {
   tiers: TierDefinition[];
 }
 
+/**
+ * Result of an escalation attempt. Discriminated on `resolved` so that
+ * `tier`/`confidence` are statically known to be present when resolved —
+ * no non-null assertions needed at the call sites.
+ */
+type EscalationOutcome =
+  | {
+      resolved: true;
+      tier: TierId;
+      confidence: number;
+      attempt: LayerAttempt;
+      fallbackAttempt?: LayerAttempt;
+    }
+  | { resolved: false; attempt: LayerAttempt };
+
 export class CascadeRouter {
   private state: LoadedState | null = null;
   private embeddingProvider: EmbeddingProvider | undefined;
@@ -48,7 +63,7 @@ export class CascadeRouter {
     return router;
   }
 
-  private async load(): Promise<void> {
+  private async load(): Promise<LoadedState> {
     const [rules, utterances, config] = await Promise.all([
       store.loadRules(),
       store.loadUtterances(),
@@ -67,14 +82,13 @@ export class CascadeRouter {
       default_agent: r.default_agent,
     }));
 
-    this.state = { rules, utterances, config, tiers };
+    const state: LoadedState = { rules, utterances, config, tiers };
+    this.state = state;
+    return state;
   }
 
   async classify(input: TaskInput, preAllocatedTaskId?: string): Promise<TaskClassification> {
-    if (!this.state) {
-      await this.load();
-    }
-    const { rules, utterances, config, tiers } = this.state!;
+    const { rules, utterances, config, tiers } = this.state ?? (await this.load());
 
     const start = performance.now();
     const prompt = input.prompt;
@@ -193,9 +207,9 @@ export class CascadeRouter {
             const esc = await this.tryEscalation(prompt, config, tiers, allCapabilities);
             trace.push(esc.attempt);
             if (esc.resolved) {
-              tier = esc.tier!;
+              tier = esc.tier;
               layer = "escalation";
-              confidence = esc.confidence!;
+              confidence = esc.confidence;
               resolved = true;
               if (esc.fallbackAttempt) trace.push(esc.fallbackAttempt);
             }
@@ -210,9 +224,9 @@ export class CascadeRouter {
           const esc = await this.tryEscalation(prompt, config, tiers, allCapabilities);
           trace.push(esc.attempt);
           if (esc.resolved) {
-            tier = esc.tier!;
+            tier = esc.tier;
             layer = "escalation";
-            confidence = esc.confidence!;
+            confidence = esc.confidence;
             resolved = true;
             if (esc.fallbackAttempt) trace.push(esc.fallbackAttempt);
           }
@@ -271,13 +285,7 @@ export class CascadeRouter {
     config: RouterConfig,
     tiers: TierDefinition[],
     allCapabilities: Set<string>,
-  ): Promise<{
-    resolved: boolean;
-    tier?: TierId;
-    confidence?: number;
-    attempt: LayerAttempt;
-    fallbackAttempt?: LayerAttempt;
-  }> {
+  ): Promise<EscalationOutcome> {
     if (!config.enable_escalation || !this.escalationProvider || tiers.length === 0) {
       const reason = !config.enable_escalation
         ? "escalation disabled"

--- a/src/services/execution.ts
+++ b/src/services/execution.ts
@@ -24,11 +24,14 @@ export async function execute(
   request: AgentRequest,
   maxRetries: number = 2,
 ): Promise<ExecutionRecord> {
+  if (!Number.isInteger(maxRetries) || maxRetries < 0) {
+    throw new Error(`maxRetries must be a non-negative integer, got: ${maxRetries}`);
+  }
+
   const agent = await findById(agentId);
   if (!agent) throw new Error(`Agent not found: ${agentId}`);
 
   const provider = getProvider(agent.provider, agent.model_id);
-  let lastRecord: ExecutionRecord | null = null;
 
   for (let attempt = 1; attempt <= maxRetries + 1; attempt++) {
     const executionId = uuidv7();
@@ -79,7 +82,6 @@ export async function execute(
       };
 
       await execRepo.insertExecution(record);
-      lastRecord = record;
 
       if (isLastAttempt) return record;
 
@@ -88,5 +90,9 @@ export async function execute(
     }
   }
 
-  return lastRecord!;
+  // Unreachable: maxRetries >= 0 guarantees the loop runs at least once, and
+  // the final iteration (attempt === maxRetries + 1) always returns via the
+  // success path or the isLastAttempt branch. Kept as a typed exhaustiveness
+  // guard so the function never silently returns undefined.
+  throw new Error("execute: retry loop exited without producing a record");
 }

--- a/tests/services/execution.test.ts
+++ b/tests/services/execution.test.ts
@@ -240,6 +240,24 @@ describe("execution service — unit tests", () => {
       insertSpy.mockRestore();
     }
   });
+
+  it("rejects a negative maxRetries before touching the DB (no null deref)", async () => {
+    // Guard runs before findById, so a spy lets us assert the DB is never hit.
+    const agentRegistryMod = await import("../../src/repositories/agent-registry.js");
+    const findByIdSpy = vi.spyOn(agentRegistryMod, "findById");
+
+    const request: AgentRequest = { task_id: "t-bad-retries", prompt: "x", context: {} };
+
+    await expect(execute("any-agent", request, -1)).rejects.toThrow(
+      /maxRetries must be a non-negative integer/,
+    );
+    await expect(execute("any-agent", request, 1.5)).rejects.toThrow(
+      /maxRetries must be a non-negative integer/,
+    );
+    expect(findByIdSpy).not.toHaveBeenCalled();
+
+    findByIdSpy.mockRestore();
+  });
 });
 
 // --- Integration tests (require Dolt) ---


### PR DESCRIPTION
## Issue #11 (High)

Non-null assertions hid genuinely-undefined paths.

## Changes
- **`execution.ts`**: validate `maxRetries` is a non-negative integer at the boundary (the only path to the trailing `return lastRecord!` with `lastRecord === null` is `maxRetries < 0`, where the loop never runs). Remove the now-unreachable `lastRecord!` in favor of a typed exhaustiveness throw.
- **`cascade-router.ts`**: make `tryEscalation` return a discriminated `EscalationOutcome` union (`{resolved: true, tier, confidence, ...}` | `{resolved: false, ...}`) so `esc.tier`/`esc.confidence` narrow without `!`. Have `load()` return `LoadedState` so `classify()` drops `this.state!`.

## Testing
`npm run build` clean; added a unit test asserting `execute()` rejects negative/non-integer `maxRetries` before any DB access. `tests/services/execution.test.ts` + `tests/cascade-router/cascade-router.test.ts` pass.