### PR TITLE
Fix #13: defensive .catch on the worker job chain

### DIFF
--- a/src/services/task-worker.ts
+++ b/src/services/task-worker.ts
@@ -87,15 +87,29 @@ function pump(): void {
   while (inflight < max && queue.length > 0) {
     const job = queue.shift()!;
     inflight++;
-    runJob(job).finally(() => {
-      inflight--;
-      tracked.delete(job.taskId);
-      if (queue.length > 0) {
-        setImmediate(pump);
-      } else {
-        maybeResolveDrain();
-      }
-    });
+    // runJob is async, so a synchronous throw in its body (e.g. from
+    // runWithContext) becomes a rejected promise — the .finally() cleanup
+    // (inflight--, tracked.delete) still runs, and the task ID never gets
+    // stranded in `tracked`. runJobInner already catches its own errors, so
+    // the .catch() here is defense-in-depth: it keeps a future regression
+    // that lets runJob reject from surfacing as an unhandled rejection (the
+    // re-raise that .finally() would otherwise propagate).
+    runJob(job)
+      .finally(() => {
+        inflight--;
+        tracked.delete(job.taskId);
+        if (queue.length > 0) {
+          setImmediate(pump);
+        } else {
+          maybeResolveDrain();
+        }
+      })
+      .catch((err) => {
+        logger.error("unexpected rejection from runJob", {
+          task_id: job.taskId,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      });
   }
 }
 

--- a/tests/services/task-worker-cleanup.test.ts
+++ b/tests/services/task-worker-cleanup.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import * as taskLog from "../../src/repositories/task-log.js";
+import * as worker from "../../src/services/task-worker.js";
+import type { RouterTaskInput } from "../../src/types/router.js";
+
+// --- Unit test for #13: the `tracked` Set must not leak (no DB required). ---
+//
+// runJobInner catches its own errors and returns, so runJob resolves even when
+// the job's work fails — and the .finally() cleanup runs on that resolution.
+// This locks in that a task ID is removed from `tracked` after the job settles
+// regardless of internal error handling, so the same ID can be re-enqueued and
+// never becomes permanently un-enqueueable.
+
+const INPUT: RouterTaskInput = { prompt: "x" };
+
+function tick(): Promise<void> {
+  // Two macrotask hops: one for setImmediate(pump), one for the job's
+  // microtask chain + .finally() to settle.
+  return new Promise((resolve) => setTimeout(resolve, 10));
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  worker._resetForTests();
+});
+
+describe("task-worker — tracked Set cleanup (#13)", () => {
+  it("releases the task ID after the job's work errors, so it can be re-enqueued", async () => {
+    // Force the job's work to fail at the very first await. runJobInner catches
+    // this and returns, so runJob resolves — the .finally() cleanup runs on that
+    // resolution, not on a rejection.
+    vi.spyOn(taskLog, "claimQueued").mockRejectedValue(new Error("boom"));
+
+    worker.start();
+    expect(worker.enqueue("task-1", INPUT)).toBe("ok");
+    // Same ID is rejected as a duplicate while still tracked/in-flight.
+    expect(worker.enqueue("task-1", INPUT)).toBe("duplicate");
+
+    await tick();
+
+    // Cleanup ran despite the error: nothing in-flight, ID released.
+    expect(worker.inspect().inflight).toBe(0);
+    expect(worker.enqueue("task-1", INPUT)).toBe("ok");
+  });
+});


### PR DESCRIPTION
## Issue #13 (High) — re-verified, no longer reproduces

The originally-reported leak does not reproduce against current code. `runJob` is declared `async`, so a synchronous throw in its body (e.g. from `runWithContext`) becomes a rejected promise — the `.finally()` cleanup (`inflight--`, `tracked.delete`) always runs, and the task ID is never stranded in `tracked`. The refactor that wrapped the worker body in an async `runJob` already closed the hole.

## Changes (defensive hardening only)
- Add a `.catch()` after the `.finally()` on the `runJob` chain so that if `runJob` ever *does* reject in the future, the re-raise that `.finally()` propagates is logged instead of surfacing as an unhandled rejection. (`runJobInner` already catches its own errors, so this is currently unreachable.)
- Add a re-verification comment explaining why the path is safe.
- Add a Dolt-free unit test asserting the ID is released and re-enqueueable after the job's work rejects.

## Testing
`npm run build` clean; `tests/services/task-worker-cleanup.test.ts` passes.