### PR TITLE
Bump hono to ^4.12.21 (Dependabot #14-17)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@hono/node-server": "^1.19.10",
         "dotenv": "^16.4.0",
-        "hono": "^4.12.7",
+        "hono": "^4.12.21",
         "mysql2": "^3.11.0",
         "pino": "^10.3.1",
         "safe-regex": "^2.1.1",
@@ -1205,9 +1205,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.18",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
-      "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
+      "version": "4.12.23",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.23.tgz",
+      "integrity": "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@hono/node-server": "^1.19.10",
     "dotenv": "^16.4.0",
-    "hono": "^4.12.7",
+    "hono": "^4.12.21",
     "mysql2": "^3.11.0",
     "pino": "^10.3.1",
     "safe-regex": "^2.1.1",


### PR DESCRIPTION
## Summary
Bumps `hono` from `^4.12.7` (installed 4.12.18) to `^4.12.21` (installs 4.12.23), clearing four open medium-severity Dependabot alerts.

## Alerts resolved
- **#17** — Cookie helper does not sanitize `sameSite`/`priority`, allowing Set-Cookie injection
- **#16** — `app.mount()` strips mount prefix using undecoded path (percent-encoded routing)
- **#15** — `ipRestriction()` bypasses static deny rules for non-canonical IPv6
- **#14** — JWT middleware accepts any Authorization scheme, not only Bearer

All four are fixed in 4.12.21.

## Risk
Low. Patch-level bump within 4.x. The vulnerable APIs (cookie helpers, `app.mount`, `ipRestriction`, JWT middleware) are **not used** in `src/` — the only Hono surface in use is `serveStatic` from `@hono/node-server` (already at patched 1.19.14). Patching regardless since the library is in the production request path.

## Verification
- `npm run build` — clean
- `npm test` — 344 passed, 181 skipped (Dolt-dependent tests skip gracefully; no Dolt in this env)