### PR TITLE
Fix #10 and #14: index agent_registry.status; fix reaper enqueue accounting

### DIFF
--- a/src/db/migrations/021_add_agent_registry_status_index.sql
+++ b/src/db/migrations/021_add_agent_registry_status_index.sql
@@ -1,0 +1,16 @@
+-- Index agent_registry.status. Every routing decision filters agents by
+-- status = 'active' (agent-selection → findByCapabilities/findAll), and the
+-- table had no index on it, so each call full-scanned the registry. Cost was
+-- linear in agent count × QPS.
+--
+-- The capability filter (JSON_CONTAINS(capabilities, ?)) still cannot use an
+-- index — JSON membership is unindexable here. But with most routing queries
+-- anchored on status = 'active', this index lets the planner restrict to the
+-- active subset first and evaluate JSON_CONTAINS only on those rows instead of
+-- the whole table. Fully indexing capabilities would require normalizing into
+-- an agent_capability(agent_id, capability_key) table — deferred as a larger
+-- change; this index is the contained, high-leverage fix.
+--
+-- IF NOT EXISTS so a crash between this DDL and the migrations_applied insert
+-- recovers cleanly on re-run (Dolt-supported; see migrations 017/019).
+CREATE INDEX IF NOT EXISTS idx_agent_registry_status ON agent_registry (status);

--- a/src/services/task-reaper.ts
+++ b/src/services/task-reaper.ts
@@ -87,6 +87,7 @@ function reconstructInput(record: taskLog.TaskLogRecord): RouterTaskInput | null
 
 export async function runReaperOnce(): Promise<{
   reEnqueued: number;
+  duplicates: number;
   failed: number;
   branchesPruned: number;
 }> {
@@ -95,11 +96,16 @@ export async function runReaperOnce(): Promise<{
 
 async function runReaperOnceInner(): Promise<{
   reEnqueued: number;
+  duplicates: number;
   failed: number;
   branchesPruned: number;
 }> {
   const ageSec = recoveryAgeSeconds();
   let reEnqueued = 0;
+  // Rows the worker refused as already queued/in-flight (the reaper raced a
+  // live worker that re-queued the same row). Counted separately so they
+  // don't inflate reEnqueued — they represent no new work.
+  let duplicates = 0;
   let failed = 0;
   let branchesPruned = 0;
 
@@ -144,8 +150,21 @@ async function runReaperOnceInner(): Promise<{
         draining = false;
         break;
       }
-      worker.enqueue(row.task_id, input);
-      reEnqueued++;
+      // canAccept() is only a pre-flight hint; enqueue()'s return is the
+      // source of truth. Branch on it so a "duplicate" (we raced a live
+      // worker that already re-queued this row) doesn't inflate reEnqueued,
+      // and a queue that filled in the canAccept→enqueue gap stops the drain
+      // rather than having the row silently dropped from this sweep.
+      const outcome = worker.enqueue(row.task_id, input);
+      if (outcome === "ok") {
+        reEnqueued++;
+      } else if (outcome === "duplicate") {
+        duplicates++;
+      } else {
+        // "queue_full" | "stopping" — the worker can't take more right now.
+        draining = false;
+        break;
+      }
     }
 
     // Stop on a short page (queue drained) or an early stop (worker full).
@@ -190,14 +209,15 @@ async function runReaperOnceInner(): Promise<{
     logger.warn("pruneSessionBranches failed", { error: (err as Error).message });
   }
 
-  if (reEnqueued > 0 || failed > 0 || branchesPruned > 0) {
+  if (reEnqueued > 0 || duplicates > 0 || failed > 0 || branchesPruned > 0) {
     logger.info("reaper sweep summary", {
       re_enqueued: reEnqueued,
+      duplicates,
       failed,
       branches_pruned: branchesPruned,
     });
   }
-  return { reEnqueued, failed, branchesPruned };
+  return { reEnqueued, duplicates, failed, branchesPruned };
 }
 
 export function startReaper(): void {

--- a/tests/db/migrations.test.ts
+++ b/tests/db/migrations.test.ts
@@ -46,16 +46,16 @@ afterAll(async () => {
 describe("migrations", () => {
   it("applies all migration files without error", async ({ skip }) => {
     if (!doltAvailable) skip();
-    // First call either runs all 20 (fresh DB) or backfills tracking from
+    // First call either runs all 21 (fresh DB) or backfills tracking from
     // an existing populated DB and returns an empty list. Either way the
     // post-condition is "every file recorded in migrations_applied."
     await runMigrations();
     const rows = await query<{ filename: string }>(
       "SELECT filename FROM migrations_applied ORDER BY filename",
     );
-    expect(rows.length).toBe(20);
+    expect(rows.length).toBe(21);
     expect(rows[0].filename).toBe("001_create_agent_registry.sql");
-    expect(rows[19].filename).toBe("020_fix_signal_value_nullable.sql");
+    expect(rows[20].filename).toBe("021_add_agent_registry_status_index.sql");
   });
 
   it("is idempotent — second run does no work", async ({ skip }) => {

--- a/tests/services/task-reaper.test.ts
+++ b/tests/services/task-reaper.test.ts
@@ -195,4 +195,54 @@ describe("task-reaper — QUEUED re-enqueue paging", () => {
     expect(enqueueSpy.mock.calls.map((c) => c[0])).toEqual(["a", "b"]);
     expect(pageSpy).toHaveBeenCalledTimes(2);
   });
+
+  it("counts duplicate enqueues separately and does not inflate reEnqueued (fix #14)", async () => {
+    process.env.WORKER_REQUEUE_PAGE_SIZE = "10";
+    stubNonQueuedWork();
+
+    const rows = [
+      makeRecord("a", "2026-06-01 00:00:01"),
+      makeRecord("b", "2026-06-01 00:00:02"),
+      makeRecord("c", "2026-06-01 00:00:03"),
+    ];
+    vi.spyOn(taskLog, "findQueuedPage").mockImplementation(pagedSource(rows));
+    vi.spyOn(worker, "canAccept").mockReturnValue(true);
+    // b was already re-queued by a live worker — enqueue refuses it as a dup.
+    const enqueueSpy = vi
+      .spyOn(worker, "enqueue")
+      .mockReturnValueOnce("ok")
+      .mockReturnValueOnce("duplicate")
+      .mockReturnValueOnce("ok");
+
+    const result = await runReaperOnce();
+
+    expect(enqueueSpy).toHaveBeenCalledTimes(3);
+    expect(result.reEnqueued).toBe(2);
+    expect(result.duplicates).toBe(1);
+  });
+
+  it("stops the drain when enqueue reports queue_full even though canAccept passed (fix #14)", async () => {
+    process.env.WORKER_REQUEUE_PAGE_SIZE = "10";
+    stubNonQueuedWork();
+
+    const rows = [
+      makeRecord("a", "2026-06-01 00:00:01"),
+      makeRecord("b", "2026-06-01 00:00:02"),
+      makeRecord("c", "2026-06-01 00:00:03"),
+    ];
+    vi.spyOn(taskLog, "findQueuedPage").mockImplementation(pagedSource(rows));
+    // canAccept is a stale pre-flight hint here: it keeps saying yes, but the
+    // queue fills between the check and the enqueue, so enqueue refuses "b".
+    vi.spyOn(worker, "canAccept").mockReturnValue(true);
+    const enqueueSpy = vi
+      .spyOn(worker, "enqueue")
+      .mockReturnValueOnce("ok")
+      .mockReturnValueOnce("queue_full");
+
+    const result = await runReaperOnce();
+
+    // Only "a" landed; the drain stopped at the queue_full without trying "c".
+    expect(result.reEnqueued).toBe(1);
+    expect(enqueueSpy.mock.calls.map((c) => c[0])).toEqual(["a", "b"]);
+  });
 });


### PR DESCRIPTION
Closes the two remaining High-tier audit items.

## #10 — `JSON_CONTAINS(capabilities)` full-scans `agent_registry`
Every routing decision filters the registry on `status = 'active'`, but there was no index on `status`, so each call full-scanned the table (cost linear in agent count × QPS).

- New migration `021_add_agent_registry_status_index.sql`: `CREATE INDEX IF NOT EXISTS idx_agent_registry_status ON agent_registry (status)` (Dolt-supported `IF NOT EXISTS`, crash-recoverable like 017/019).
- The planner now restricts to the active subset via the index and evaluates the inherently-unindexable `JSON_CONTAINS` only on those rows.
- **Deferred:** the in-process active-agent cache / `agent_capability` normalization — a larger change tracked for when registry size or QPS makes the index alone insufficient.

## #14 — Reaper double-counts re-enqueues
`task-reaper.ts` discarded `worker.enqueue()`'s return, so `"duplicate"` results inflated `reEnqueued` with no observability, and the `canAccept()`→`enqueue()` gap could silently drop a row the worker had just refused.

- Branch on `EnqueueResult`: `"ok"` → `reEnqueued`; `"duplicate"` → new `duplicates` tally (surfaced in the sweep-summary log and the `runReaperOnce` return); `"queue_full"`/`"stopping"` → stop the drain so the row stays QUEUED for the next sweep.

## Testing
- `npm run build` clean.
- Verified against local Dolt: migration 021 applies, is idempotent on re-run, and `SHOW INDEX` confirms the index.
- Full suite: **521 passed, 6 skipped, 0 failures**. Added two reaper unit tests (duplicate counting; queue-full mid-drain stop) and bumped the migrations count assertion 20→21.