### PR TITLE
Fix #73: define rate-limiter trust-proxy posture

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,24 @@ OPENAI_API_KEY=
 # HTTP server
 PORT=3000
 
+# Rate limiting
+# Number of trusted reverse-proxy hops in front of this server. The client IP
+# used for per-IP rate limiting is read from X-Forwarded-For by counting this
+# many entries from the RIGHT — the rightmost entry is appended by the proxy
+# nearest this server and cannot be forged by clients, so addresses a client
+# prepends are ignored.
+#   0 = no proxy; use the socket peer address directly (direct exposure)
+#   1 = one trusted proxy / load balancer (client -> LB -> app)
+#   2 = two hops (client -> CDN -> LB -> app)
+# REQUIRED in production: the server refuses to start if this is unset, because
+# the wrong posture silently degrades per-IP limiting into a single global
+# bucket (behind a load balancer the socket peer is identical for every
+# client). Set it deliberately even when 0.
+# NOTE: the limiter is in-memory and per-process. Multi-replica deployments do
+# NOT share buckets, so the effective limit is (replicas x configured). Use a
+# shared store (e.g. Redis) for coordinated limiting across replicas.
+RATE_LIMIT_TRUSTED_PROXY_HOPS=0
+
 # Async task pipeline
 # Number of pipeline jobs the in-process worker runs in parallel.
 WORKER_CONCURRENCY=4

--- a/README.md
+++ b/README.md
@@ -740,6 +740,29 @@ The `seed:embeddings` step calls the OpenAI embeddings API once to compute vecto
 | `ANTHROPIC_API_KEY` | —           | Anthropic API key (for Claude models and Layer 2 escalation) |
 | `OPENAI_API_KEY`    | —           | OpenAI API key (for GPT models and embedding computation)    |
 | `PORT`              | `3000`      | HTTP server port                                             |
+| `RATE_LIMIT_TRUSTED_PROXY_HOPS` | `0` | Trusted reverse-proxy hops for client-IP resolution (see below). **Required in production.** |
+
+#### Rate limiting & reverse proxies
+
+Per-IP rate limiting derives the client IP from `X-Forwarded-For` by counting
+`RATE_LIMIT_TRUSTED_PROXY_HOPS` entries **from the right** — the rightmost entry
+is the address appended by the proxy nearest this server and cannot be forged by
+clients (entries a client prepends are ignored). Set it to the number of trusted
+proxies in front of the server:
+
+- `0` — direct exposure; the socket peer address is used (`X-Forwarded-For` is ignored).
+- `1` — one load balancer / reverse proxy (`client → LB → app`).
+- `2` — two hops (`client → CDN → LB → app`).
+
+This **must be set explicitly in production** — the server refuses to start
+otherwise. The reason: behind a load balancer with the value unset, every
+request shares the proxy's socket IP, so the per-IP limiter silently collapses
+into a single global bucket that one client (or attacker) can exhaust for
+everyone. Setting it to `0` is a valid, deliberate choice for direct exposure.
+
+> The limiter is in-memory and per-process. Multi-replica deployments do **not**
+> share buckets, so the effective limit is `replicas × configured`. Use a shared
+> store (e.g. Redis) for coordinated limiting across replicas.
 
 ### Running
 

--- a/src/api/app.ts
+++ b/src/api/app.ts
@@ -2,7 +2,7 @@ import { Hono } from "hono";
 import { serveStatic } from "@hono/node-server/serve-static";
 import { requestId } from "./middleware/request-id.js";
 import { createApiKeyAuth } from "./middleware/api-key-auth.js";
-import { rateLimit } from "./middleware/rate-limit.js";
+import { rateLimit, parseTrustedProxyHopsEnv } from "./middleware/rate-limit.js";
 import { errorHandler } from "./middleware/error-handler.js";
 import { health } from "./routes/health.js";
 import { agents } from "./routes/agents.js";
@@ -27,14 +27,14 @@ export function createApp(): Hono {
   if (process.env.NODE_ENV === "production" && !process.env.HAOL_API_KEY) {
     throw new Error("HAOL_API_KEY must be set in production");
   }
-  // Likewise refuse to serve with an undefined trust-proxy posture in
-  // production — an unset value silently degrades per-IP limiting to a single
-  // global bucket behind a load balancer. Must be set explicitly (0 = direct
-  // exposure). Mirrors validateRateLimitConfig() for alternate entry points.
-  if (
-    process.env.NODE_ENV === "production" &&
-    (process.env.RATE_LIMIT_TRUSTED_PROXY_HOPS ?? "") === ""
-  ) {
+  // Likewise refuse to serve with an undefined (or invalid) trust-proxy
+  // posture in production — an unset value silently degrades per-IP limiting
+  // to a single global bucket behind a load balancer, and an invalid value
+  // falls back to the same hops=0 footgun. Must be set explicitly (0 = direct
+  // exposure). Shares parseTrustedProxyHopsEnv() with validateRateLimitConfig()
+  // so both paths reject the same inputs; parse throws RangeError on an invalid
+  // value, undefined means unset.
+  if (process.env.NODE_ENV === "production" && parseTrustedProxyHopsEnv() === undefined) {
     throw new Error("RATE_LIMIT_TRUSTED_PROXY_HOPS must be set in production");
   }
 

--- a/src/api/app.ts
+++ b/src/api/app.ts
@@ -27,6 +27,16 @@ export function createApp(): Hono {
   if (process.env.NODE_ENV === "production" && !process.env.HAOL_API_KEY) {
     throw new Error("HAOL_API_KEY must be set in production");
   }
+  // Likewise refuse to serve with an undefined trust-proxy posture in
+  // production — an unset value silently degrades per-IP limiting to a single
+  // global bucket behind a load balancer. Must be set explicitly (0 = direct
+  // exposure). Mirrors validateRateLimitConfig() for alternate entry points.
+  if (
+    process.env.NODE_ENV === "production" &&
+    (process.env.RATE_LIMIT_TRUSTED_PROXY_HOPS ?? "") === ""
+  ) {
+    throw new Error("RATE_LIMIT_TRUSTED_PROXY_HOPS must be set in production");
+  }
 
   const app = new Hono();
   const apiKeyAuth = createApiKeyAuth();

--- a/src/api/middleware/rate-limit.ts
+++ b/src/api/middleware/rate-limit.ts
@@ -54,9 +54,7 @@ export function parseTrustedProxyHopsEnv(): number | undefined {
   if (raw === undefined || raw.trim() === "") return undefined;
   const trimmed = raw.trim();
   if (!/^\d+$/.test(trimmed)) {
-    throw new RangeError(
-      `${TRUSTED_PROXY_HOPS_ENV} must be a non-negative integer (got "${raw}")`,
-    );
+    throw new RangeError(`${TRUSTED_PROXY_HOPS_ENV} must be a non-negative integer (got "${raw}")`);
   }
   return parseInt(trimmed, 10);
 }

--- a/src/api/middleware/rate-limit.ts
+++ b/src/api/middleware/rate-limit.ts
@@ -1,4 +1,4 @@
-import type { MiddlewareHandler } from "hono";
+import type { Context, MiddlewareHandler } from "hono";
 import { getConnInfo } from "@hono/node-server/conninfo";
 import { logger } from "../../logging/logger.js";
 
@@ -13,11 +13,21 @@ interface RateLimitOptions {
   /** Window duration in milliseconds. */
   windowMs: number;
   /**
-   * Whether to trust the X-Forwarded-For header for client IP identification.
-   * Only enable this when running behind a trusted reverse proxy.
-   * Default: false (uses socket remote address for per-IP limiting).
+   * Number of trusted reverse-proxy hops in front of this server. The client
+   * IP used for per-IP limiting is read from `X-Forwarded-For` by counting
+   * this many entries from the RIGHT — the rightmost entry is the one appended
+   * by the proxy nearest this server, which a client cannot forge. Counting
+   * from the right means any extra addresses a client prepends are ignored, so
+   * an attacker can't rotate the leftmost value to escape their bucket.
+   *
+   *   0 → ignore `X-Forwarded-For` entirely; use the socket peer address.
+   *   1 → client → [trusted proxy] → app   (rightmost XFF entry)
+   *   2 → client → [CDN] → [LB] → app      (2nd-from-right XFF entry)
+   *
+   * When omitted, falls back to the RATE_LIMIT_TRUSTED_PROXY_HOPS env var
+   * (default 0). Ignored when `global` is set.
    */
-  trustProxy?: boolean;
+  trustedProxyHops?: number;
   /**
    * Use a single shared bucket for all clients instead of per-IP.
    * Useful for endpoints that should have a process-wide limit
@@ -27,17 +37,104 @@ interface RateLimitOptions {
   global?: boolean;
 }
 
+const TRUSTED_PROXY_HOPS_ENV = "RATE_LIMIT_TRUSTED_PROXY_HOPS";
+
+function envTrustedProxyHops(): number {
+  const raw = process.env[TRUSTED_PROXY_HOPS_ENV];
+  if (raw === undefined || raw === "") return 0;
+  const n = parseInt(raw, 10);
+  return Number.isFinite(n) && n >= 0 ? n : 0;
+}
+
+/**
+ * Validate rate-limiter configuration at startup. Mirrors
+ * validateApiKeyConfig(): in production we refuse to start with an *undefined*
+ * trust-proxy posture. The silent default (use the socket peer) collapses
+ * every client into one bucket when the server sits behind a load balancer —
+ * the per-IP limiter becomes a single global bucket that one noisy client, or
+ * an attacker, can exhaust for everyone. Forcing an explicit value (even 0,
+ * for direct exposure) removes that footgun.
+ *
+ * Call before binding the server.
+ */
+export function validateRateLimitConfig(): void {
+  if (process.env.NODE_ENV !== "production") return;
+  const raw = process.env[TRUSTED_PROXY_HOPS_ENV];
+  if (raw === undefined || raw === "") {
+    logger.fatal(
+      `${TRUSTED_PROXY_HOPS_ENV} is not set; refusing to start in production with an ` +
+        `undefined trust-proxy posture. Set it to the number of trusted reverse-proxy ` +
+        `hops in front of this server (0 for direct exposure).`,
+      { component: "rate-limit" },
+    );
+    process.exit(1);
+  }
+  const n = parseInt(raw, 10);
+  if (!Number.isFinite(n) || n < 0) {
+    logger.fatal(`${TRUSTED_PROXY_HOPS_ENV} must be a non-negative integer`, {
+      component: "rate-limit",
+      value: raw,
+    });
+    process.exit(1);
+  }
+  logger.info("rate-limit trust-proxy posture", {
+    component: "rate-limit",
+    trusted_proxy_hops: n,
+  });
+}
+
+/**
+ * Resolve the client IP used as the per-IP bucket key.
+ *
+ * With `hops > 0` the address is taken from `X-Forwarded-For` counting `hops`
+ * entries from the right (see RateLimitOptions.trustedProxyHops). If the header
+ * is missing or has fewer entries than the configured chain, the request did
+ * not traverse the expected proxies (a direct hit or a spoof attempt) — we do
+ * NOT trust a partial chain and fall back to the socket peer.
+ */
+function resolveClientIp(c: Context, hops: number): string {
+  if (hops > 0) {
+    const list =
+      c.req
+        .header("x-forwarded-for")
+        ?.split(",")
+        .map((s) => s.trim())
+        .filter(Boolean) ?? [];
+    const idx = list.length - hops;
+    if (idx >= 0 && idx < list.length) return list[idx];
+    logger.warn("X-Forwarded-For shorter than trustedProxyHops — using socket peer", {
+      component: "rate-limit",
+      trusted_proxy_hops: hops,
+      xff_entries: list.length,
+    });
+  }
+  try {
+    return getConnInfo(c).remote.address ?? "unknown";
+  } catch {
+    // getConnInfo fails without a real socket (tests, non-Node adapters).
+    // Fall back to a sentinel distinct from the "global" mode key so the
+    // per-IP and global buckets never collide if a bucket store is ever
+    // shared across middleware instances.
+    logger.warn("could not resolve client IP — using shared bucket", {
+      component: "rate-limit",
+    });
+    return "unknown";
+  }
+}
+
 /**
  * Simple in-memory sliding-window rate limiter (token bucket variant).
  *
  * Each unique client IP gets a bucket that refills at a constant rate.
  * When the bucket is empty the request is rejected with 429.
  *
- * NOT suitable for multi-process / clustered deployments — use Redis or
- * similar in that case. Fine for a single-process Hono server.
+ * NOT suitable for multi-process / clustered deployments: buckets live in this
+ * process only, so N replicas yield an effective limit of N × `limit`. Use a
+ * shared store (Redis or similar) for coordinated limiting across replicas.
  */
 export function rateLimit(opts: RateLimitOptions): MiddlewareHandler {
-  const { limit, windowMs, trustProxy = false, global: globalBucket = false } = opts;
+  const { limit, windowMs, global: globalBucket = false } = opts;
+  const hops = opts.trustedProxyHops ?? envTrustedProxyHops();
   const buckets = new Map<string, BucketEntry>();
 
   // Refill rate: tokens per millisecond
@@ -63,32 +160,9 @@ export function rateLimit(opts: RateLimitOptions): MiddlewareHandler {
     const now = Date.now();
     prune(now);
 
-    // Identify the bucket key.
     // global: all clients share one bucket (for process-wide limits).
-    // trustProxy: read X-Forwarded-For from a trusted reverse proxy.
-    // default: use the socket remote address via @hono/node-server.
-    // Note: getConnInfo requires @hono/node-server; other adapters will
-    // fall back to the shared "unknown" bucket.
-    let key = "global";
-    if (!globalBucket) {
-      if (trustProxy) {
-        key = c.req.header("x-forwarded-for")?.split(",")[0]?.trim() ?? "unknown";
-      } else {
-        try {
-          const info = getConnInfo(c);
-          key = info.remote.address ?? "unknown";
-        } catch {
-          // getConnInfo fails without a real socket (tests, non-Node adapters).
-          // Fall back to a sentinel distinct from the "global" mode key so
-          // the per-IP and global buckets never collide if the bucket store
-          // is ever shared across middleware instances.
-          key = "unknown";
-          logger.warn("could not resolve client IP — using shared bucket", {
-            component: "rate-limit",
-          });
-        }
-      }
-    }
+    // otherwise: per-client, keyed on the resolved client IP.
+    const key = globalBucket ? "global" : resolveClientIp(c, hops);
 
     let entry = buckets.get(key);
     if (!entry) {

--- a/src/api/middleware/rate-limit.ts
+++ b/src/api/middleware/rate-limit.ts
@@ -37,13 +37,47 @@ interface RateLimitOptions {
   global?: boolean;
 }
 
-const TRUSTED_PROXY_HOPS_ENV = "RATE_LIMIT_TRUSTED_PROXY_HOPS";
+export const TRUSTED_PROXY_HOPS_ENV = "RATE_LIMIT_TRUSTED_PROXY_HOPS";
 
-function envTrustedProxyHops(): number {
+/**
+ * Strictly parse RATE_LIMIT_TRUSTED_PROXY_HOPS. Returns `undefined` when unset
+ * or empty (callers decide whether that's allowed — required in production,
+ * defaults to 0 elsewhere). Throws RangeError on anything that isn't a
+ * non-negative integer, so a typo like `abc` or `-1` is never silently coerced
+ * to 0 (which would mean "no proxy" — exactly wrong behind a load balancer).
+ *
+ * `parseInt` is too lenient (`parseInt("1abc")` is 1), so we validate the raw
+ * string against a digits-only pattern.
+ */
+export function parseTrustedProxyHopsEnv(): number | undefined {
   const raw = process.env[TRUSTED_PROXY_HOPS_ENV];
-  if (raw === undefined || raw === "") return 0;
-  const n = parseInt(raw, 10);
-  return Number.isFinite(n) && n >= 0 ? n : 0;
+  if (raw === undefined || raw.trim() === "") return undefined;
+  const trimmed = raw.trim();
+  if (!/^\d+$/.test(trimmed)) {
+    throw new RangeError(
+      `${TRUSTED_PROXY_HOPS_ENV} must be a non-negative integer (got "${raw}")`,
+    );
+  }
+  return parseInt(trimmed, 10);
+}
+
+/**
+ * Resolve the hop count for limiter construction (runs in every environment).
+ * Never throws: an invalid value is logged and treated as 0. In production
+ * validateRateLimitConfig() rejects an invalid value at startup before any
+ * limiter is built, so this fallback only applies in dev/test — where a loud
+ * warn is enough to surface the misconfiguration.
+ */
+function envTrustedProxyHops(): number {
+  try {
+    return parseTrustedProxyHopsEnv() ?? 0;
+  } catch {
+    logger.warn(`${TRUSTED_PROXY_HOPS_ENV} is invalid — falling back to 0 (no proxy)`, {
+      component: "rate-limit",
+      value: process.env[TRUSTED_PROXY_HOPS_ENV],
+    });
+    return 0;
+  }
 }
 
 /**
@@ -59,8 +93,17 @@ function envTrustedProxyHops(): number {
  */
 export function validateRateLimitConfig(): void {
   if (process.env.NODE_ENV !== "production") return;
-  const raw = process.env[TRUSTED_PROXY_HOPS_ENV];
-  if (raw === undefined || raw === "") {
+  let hops: number | undefined;
+  try {
+    hops = parseTrustedProxyHopsEnv();
+  } catch (err) {
+    logger.fatal((err as Error).message, {
+      component: "rate-limit",
+      value: process.env[TRUSTED_PROXY_HOPS_ENV],
+    });
+    process.exit(1);
+  }
+  if (hops === undefined) {
     logger.fatal(
       `${TRUSTED_PROXY_HOPS_ENV} is not set; refusing to start in production with an ` +
         `undefined trust-proxy posture. Set it to the number of trusted reverse-proxy ` +
@@ -69,17 +112,9 @@ export function validateRateLimitConfig(): void {
     );
     process.exit(1);
   }
-  const n = parseInt(raw, 10);
-  if (!Number.isFinite(n) || n < 0) {
-    logger.fatal(`${TRUSTED_PROXY_HOPS_ENV} must be a non-negative integer`, {
-      component: "rate-limit",
-      value: raw,
-    });
-    process.exit(1);
-  }
   logger.info("rate-limit trust-proxy posture", {
     component: "rate-limit",
-    trusted_proxy_hops: n,
+    trusted_proxy_hops: hops,
   });
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,13 +3,16 @@ import { loadConfig } from "./config.js";
 import { createPool, healthCheck } from "./db/connection.js";
 import { createApp } from "./api/app.js";
 import { validateApiKeyConfig } from "./api/middleware/api-key-auth.js";
+import { validateRateLimitConfig } from "./api/middleware/rate-limit.js";
 import * as worker from "./services/task-worker.js";
 import { startReaper, stopReaper, runReaperOnce } from "./services/task-reaper.js";
 import { logger } from "./logging/logger.js";
 
 async function main() {
-  // Fail fast if production auth is misconfigured — before binding the server.
+  // Fail fast if production auth or rate-limit posture is misconfigured —
+  // before binding the server.
   validateApiKeyConfig();
+  validateRateLimitConfig();
 
   const config = loadConfig();
   createPool(config.dolt);

--- a/tests/api/middleware/rate-limit.test.ts
+++ b/tests/api/middleware/rate-limit.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { Hono } from "hono";
 import { rateLimit, validateRateLimitConfig } from "../../../src/api/middleware/rate-limit.js";
+import { createApp } from "../../../src/api/app.js";
 import { _setDestinationForTests } from "../../../src/logging/logger.js";
 import { CaptureStream, LogLevel, setLogLevel } from "../../helpers/capture-stream.js";
 
@@ -151,8 +152,13 @@ describe("rateLimit middleware", () => {
     });
 
     it("ignores X-Forwarded-For entirely when hops=0 (default)", async () => {
-      // No hops configured → socket peer only. In tests getConnInfo throws, so
-      // every request shares the 'unknown' bucket regardless of XFF.
+      // No hops configured → socket peer only, so XFF must be ignored.
+      // NOTE: this test depends on the no-socket test environment — Hono's
+      // app.request() has no real socket, so getConnInfo throws and BOTH
+      // requests resolve to the shared 'unknown' bucket (hence the second
+      // 429). In an environment where getConnInfo resolves a real peer, both
+      // requests would share that peer's bucket instead; either way the point
+      // — that the two distinct XFF values do NOT yield two buckets — holds.
       const app = buildApp({ limit: 1, windowMs: 60_000 });
       const r1 = await app.request("/ping", reqFrom("10.0.0.1"));
       const r2 = await app.request("/ping", reqFrom("10.0.0.2"));
@@ -160,6 +166,19 @@ describe("rateLimit middleware", () => {
       expect(r2.status).toBe(429); // XFF ignored → same shared bucket
       const warns = capture.records(LogLevel.WARN);
       expect(warns[0]).toMatchObject({ component: "rate-limit" });
+    });
+
+    it("warns and falls back to hops=0 when the env value is invalid", async () => {
+      vi.stubEnv("RATE_LIMIT_TRUSTED_PROXY_HOPS", "abc");
+      // Invalid env value → construction warns and treats it as hops=0, so XFF
+      // is ignored and distinct clients share the 'unknown' bucket.
+      const app = buildApp({ limit: 1, windowMs: 60_000 });
+      const r1 = await app.request("/ping", reqXff("1.1.1.1, 203.0.113.7"));
+      const r2 = await app.request("/ping", reqXff("9.9.9.9, 203.0.113.8"));
+      expect(r1.status).toBe(200);
+      expect(r2.status).toBe(429);
+      const warns = capture.records(LogLevel.WARN);
+      expect(warns.some((w) => /is invalid — falling back to 0/.test(String(w.msg)))).toBe(true);
     });
 
     it("falls back to the shared bucket when hops>0 and X-Forwarded-For is missing", async () => {
@@ -323,5 +342,35 @@ describe("validateRateLimitConfig", () => {
     vi.stubEnv("RATE_LIMIT_TRUSTED_PROXY_HOPS", "1");
     expect(() => validateRateLimitConfig()).not.toThrow();
     expect(exitSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("createApp() rate-limit defense-in-depth (production)", () => {
+  // HAOL_API_KEY is set so the API-key guard (checked first) passes and we
+  // exercise the trust-proxy guard. createApp() builds the app graph only —
+  // no DB connection — so it's safe to construct in a unit test.
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("throws when RATE_LIMIT_TRUSTED_PROXY_HOPS is unset in production", () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("HAOL_API_KEY", "k");
+    vi.stubEnv("RATE_LIMIT_TRUSTED_PROXY_HOPS", "");
+    expect(() => createApp()).toThrow(/RATE_LIMIT_TRUSTED_PROXY_HOPS must be set/);
+  });
+
+  it("throws when RATE_LIMIT_TRUSTED_PROXY_HOPS is invalid in production", () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("HAOL_API_KEY", "k");
+    vi.stubEnv("RATE_LIMIT_TRUSTED_PROXY_HOPS", "-1");
+    expect(() => createApp()).toThrow(/must be a non-negative integer/);
+  });
+
+  it("does not throw when a valid value is set in production", () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("HAOL_API_KEY", "k");
+    vi.stubEnv("RATE_LIMIT_TRUSTED_PROXY_HOPS", "1");
+    expect(() => createApp()).not.toThrow();
   });
 });

--- a/tests/api/middleware/rate-limit.test.ts
+++ b/tests/api/middleware/rate-limit.test.ts
@@ -1,13 +1,13 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { Hono } from "hono";
-import { rateLimit } from "../../../src/api/middleware/rate-limit.js";
+import { rateLimit, validateRateLimitConfig } from "../../../src/api/middleware/rate-limit.js";
 import { _setDestinationForTests } from "../../../src/logging/logger.js";
 import { CaptureStream, LogLevel, setLogLevel } from "../../helpers/capture-stream.js";
 
 interface AppOpts {
   limit: number;
   windowMs: number;
-  trustProxy?: boolean;
+  trustedProxyHops?: number;
   global?: boolean;
 }
 
@@ -20,6 +20,10 @@ function buildApp(opts: AppOpts) {
 
 function reqFrom(ip: string) {
   return { headers: { "x-forwarded-for": ip } };
+}
+
+function reqXff(xff: string) {
+  return { headers: { "x-forwarded-for": xff } };
 }
 
 describe("rateLimit middleware", () => {
@@ -38,11 +42,12 @@ describe("rateLimit middleware", () => {
     _setDestinationForTests(undefined);
     restoreLogLevel();
     vi.useRealTimers();
+    vi.unstubAllEnvs();
   });
 
   describe("token bucket basics", () => {
     it("allows the first `limit` requests within the window", async () => {
-      const app = buildApp({ limit: 3, windowMs: 60_000, trustProxy: true });
+      const app = buildApp({ limit: 3, windowMs: 60_000, trustedProxyHops: 1 });
       for (let i = 0; i < 3; i++) {
         const res = await app.request("/ping", reqFrom("10.0.0.1"));
         expect(res.status).toBe(200);
@@ -50,7 +55,7 @@ describe("rateLimit middleware", () => {
     });
 
     it("rejects with 429 once the bucket is empty", async () => {
-      const app = buildApp({ limit: 2, windowMs: 60_000, trustProxy: true });
+      const app = buildApp({ limit: 2, windowMs: 60_000, trustedProxyHops: 1 });
       await app.request("/ping", reqFrom("10.0.0.1"));
       await app.request("/ping", reqFrom("10.0.0.1"));
       const res = await app.request("/ping", reqFrom("10.0.0.1"));
@@ -59,7 +64,7 @@ describe("rateLimit middleware", () => {
     });
 
     it("sets a Retry-After header on 429 responses", async () => {
-      const app = buildApp({ limit: 1, windowMs: 60_000, trustProxy: true });
+      const app = buildApp({ limit: 1, windowMs: 60_000, trustedProxyHops: 1 });
       await app.request("/ping", reqFrom("10.0.0.1"));
       const res = await app.request("/ping", reqFrom("10.0.0.1"));
       expect(res.status).toBe(429);
@@ -69,7 +74,7 @@ describe("rateLimit middleware", () => {
     });
 
     it("sets X-RateLimit-Limit/Remaining/Reset headers on success", async () => {
-      const app = buildApp({ limit: 5, windowMs: 60_000, trustProxy: true });
+      const app = buildApp({ limit: 5, windowMs: 60_000, trustedProxyHops: 1 });
       const res = await app.request("/ping", reqFrom("10.0.0.1"));
       expect(res.headers.get("X-RateLimit-Limit")).toBe("5");
       const remaining = Number(res.headers.get("X-RateLimit-Remaining"));
@@ -79,7 +84,7 @@ describe("rateLimit middleware", () => {
     });
 
     it("decrements X-RateLimit-Remaining on each successful request", async () => {
-      const app = buildApp({ limit: 3, windowMs: 60_000, trustProxy: true });
+      const app = buildApp({ limit: 3, windowMs: 60_000, trustedProxyHops: 1 });
       const r1 = await app.request("/ping", reqFrom("10.0.0.1"));
       const r2 = await app.request("/ping", reqFrom("10.0.0.1"));
       const r3 = await app.request("/ping", reqFrom("10.0.0.1"));
@@ -89,9 +94,9 @@ describe("rateLimit middleware", () => {
     });
   });
 
-  describe("per-IP isolation (trustProxy)", () => {
+  describe("per-IP isolation", () => {
     it("does not let one IP exhaust another's bucket", async () => {
-      const app = buildApp({ limit: 1, windowMs: 60_000, trustProxy: true });
+      const app = buildApp({ limit: 1, windowMs: 60_000, trustedProxyHops: 1 });
       const a1 = await app.request("/ping", reqFrom("10.0.0.1"));
       const a2 = await app.request("/ping", reqFrom("10.0.0.1"));
       const b1 = await app.request("/ping", reqFrom("10.0.0.2"));
@@ -99,26 +104,78 @@ describe("rateLimit middleware", () => {
       expect(a2.status).toBe(429);
       expect(b1.status).toBe(200);
     });
+  });
 
-    it("uses the first IP from a comma-separated X-Forwarded-For chain", async () => {
-      const app = buildApp({ limit: 1, windowMs: 60_000, trustProxy: true });
-      // Two requests share the leftmost IP — second should 429.
-      const r1 = await app.request("/ping", {
-        headers: { "x-forwarded-for": "10.0.0.5, 10.0.0.6, 192.168.1.1" },
-      });
-      const r2 = await app.request("/ping", {
-        headers: { "x-forwarded-for": "10.0.0.5, 192.168.1.99" },
-      });
+  describe("trusted-proxy hop resolution", () => {
+    it("reads the client IP from the right per trustedProxyHops, ignoring prepended entries (spoof-resistant)", async () => {
+      // hops=1: the real client IP is the rightmost entry (appended by our LB).
+      // An attacker who rotates the LEFTMOST (client-supplied) value must NOT
+      // get a fresh bucket — both requests share the rightmost IP.
+      const app = buildApp({ limit: 1, windowMs: 60_000, trustedProxyHops: 1 });
+      const r1 = await app.request("/ping", reqXff("1.1.1.1, 203.0.113.7"));
+      const r2 = await app.request("/ping", reqXff("9.9.9.9, 203.0.113.7"));
+      expect(r1.status).toBe(200);
+      expect(r2.status).toBe(429); // same rightmost IP → same bucket
+    });
+
+    it("isolates distinct real clients by the right-anchored IP", async () => {
+      const app = buildApp({ limit: 1, windowMs: 60_000, trustedProxyHops: 1 });
+      const a = await app.request("/ping", reqXff("1.1.1.1, 203.0.113.7"));
+      const b = await app.request("/ping", reqXff("1.1.1.1, 203.0.113.8"));
+      expect(a.status).toBe(200);
+      expect(b.status).toBe(200); // different rightmost IP → different bucket
+    });
+
+    it("counts the configured number of hops from the right (hops=2)", async () => {
+      // client -> CDN -> LB -> app. XFF = "<client>, <cdn>"; the LB's own peer
+      // (cdn) is the connection, the client is 2 from the right.
+      const app = buildApp({ limit: 1, windowMs: 60_000, trustedProxyHops: 2 });
+      // Same client, different downstream proxy hop — must still share a bucket.
+      const r1 = await app.request("/ping", reqXff("198.51.100.5, 10.0.0.1"));
+      const r2 = await app.request("/ping", reqXff("198.51.100.5, 10.0.0.2"));
       expect(r1.status).toBe(200);
       expect(r2.status).toBe(429);
     });
 
-    it("falls back to a shared 'unknown' bucket when X-Forwarded-For is missing", async () => {
-      // With trustProxy=true and no header, the key resolves to 'unknown' —
-      // every client without the header shares one bucket.
-      const app = buildApp({ limit: 1, windowMs: 60_000, trustProxy: true });
+    it("falls back to the socket peer (and warns) when XFF is shorter than the hop count", async () => {
+      // hops=2 but only one XFF entry — the request didn't traverse the full
+      // chain. We must not trust the partial chain; fall back to socket (which
+      // throws in tests → 'unknown' shared bucket).
+      const app = buildApp({ limit: 1, windowMs: 60_000, trustedProxyHops: 2 });
+      const r1 = await app.request("/ping", reqXff("203.0.113.7"));
+      const r2 = await app.request("/ping", reqXff("203.0.113.9"));
+      expect(r1.status).toBe(200);
+      expect(r2.status).toBe(429); // both fell back to the shared 'unknown' bucket
+      const warns = capture.records(LogLevel.WARN);
+      expect(warns.some((w) => /shorter than trustedProxyHops/.test(String(w.msg)))).toBe(true);
+    });
+
+    it("ignores X-Forwarded-For entirely when hops=0 (default)", async () => {
+      // No hops configured → socket peer only. In tests getConnInfo throws, so
+      // every request shares the 'unknown' bucket regardless of XFF.
+      const app = buildApp({ limit: 1, windowMs: 60_000 });
+      const r1 = await app.request("/ping", reqFrom("10.0.0.1"));
+      const r2 = await app.request("/ping", reqFrom("10.0.0.2"));
+      expect(r1.status).toBe(200);
+      expect(r2.status).toBe(429); // XFF ignored → same shared bucket
+      const warns = capture.records(LogLevel.WARN);
+      expect(warns[0]).toMatchObject({ component: "rate-limit" });
+    });
+
+    it("falls back to the shared bucket when hops>0 and X-Forwarded-For is missing", async () => {
+      const app = buildApp({ limit: 1, windowMs: 60_000, trustedProxyHops: 1 });
       const r1 = await app.request("/ping");
       const r2 = await app.request("/ping");
+      expect(r1.status).toBe(200);
+      expect(r2.status).toBe(429);
+    });
+
+    it("uses RATE_LIMIT_TRUSTED_PROXY_HOPS when trustedProxyHops is omitted", async () => {
+      vi.stubEnv("RATE_LIMIT_TRUSTED_PROXY_HOPS", "1");
+      const app = buildApp({ limit: 1, windowMs: 60_000 });
+      // env hops=1 → rightmost is the key; same rightmost shares a bucket.
+      const r1 = await app.request("/ping", reqXff("1.1.1.1, 203.0.113.7"));
+      const r2 = await app.request("/ping", reqXff("9.9.9.9, 203.0.113.7"));
       expect(r1.status).toBe(200);
       expect(r2.status).toBe(429);
     });
@@ -133,8 +190,8 @@ describe("rateLimit middleware", () => {
       expect(r2.status).toBe(429);
     });
 
-    it("global mode ignores X-Forwarded-For even with trustProxy unset", async () => {
-      const app = buildApp({ limit: 2, windowMs: 60_000, global: true });
+    it("global mode ignores X-Forwarded-For even with hops configured", async () => {
+      const app = buildApp({ limit: 2, windowMs: 60_000, global: true, trustedProxyHops: 1 });
       await app.request("/ping", reqFrom("10.0.0.1"));
       await app.request("/ping", reqFrom("10.0.0.2"));
       const r3 = await app.request("/ping", reqFrom("10.0.0.3"));
@@ -142,27 +199,11 @@ describe("rateLimit middleware", () => {
     });
   });
 
-  describe("default mode (no trustProxy, no socket)", () => {
-    it("falls back to a shared bucket when getConnInfo fails", async () => {
-      // Hono's app.request() has no real socket — getConnInfo throws and the
-      // middleware logs a warn, then uses the "unknown" sentinel bucket
-      // (distinct from the "global" key used by global mode).
-      const app = buildApp({ limit: 1, windowMs: 60_000 });
-      const r1 = await app.request("/ping");
-      const r2 = await app.request("/ping");
-      expect(r1.status).toBe(200);
-      expect(r2.status).toBe(429);
-      const warns = capture.records(LogLevel.WARN);
-      expect(warns.length).toBeGreaterThan(0);
-      expect(warns[0]).toMatchObject({ component: "rate-limit" });
-    });
-  });
-
   describe("token refill", () => {
     it("refills tokens proportionally to elapsed time", async () => {
       vi.useFakeTimers();
       vi.setSystemTime(new Date(2026, 0, 1, 0, 0, 0));
-      const app = buildApp({ limit: 4, windowMs: 4_000, trustProxy: true });
+      const app = buildApp({ limit: 4, windowMs: 4_000, trustedProxyHops: 1 });
       // Drain the bucket
       for (let i = 0; i < 4; i++) {
         await app.request("/ping", reqFrom("10.0.0.1"));
@@ -183,7 +224,7 @@ describe("rateLimit middleware", () => {
     it("caps refill at the configured limit (no token accumulation past the cap)", async () => {
       vi.useFakeTimers();
       vi.setSystemTime(new Date(2026, 0, 1, 0, 0, 0));
-      const app = buildApp({ limit: 2, windowMs: 1_000, trustProxy: true });
+      const app = buildApp({ limit: 2, windowMs: 1_000, trustedProxyHops: 1 });
       await app.request("/ping", reqFrom("10.0.0.1")); // 1 token left
       // Wait far longer than the window — bucket should refill to cap, not beyond.
       vi.advanceTimersByTime(10 * 60_000);
@@ -205,7 +246,7 @@ describe("rateLimit middleware", () => {
       // bucket (full quota) on its next request.
       vi.useFakeTimers();
       vi.setSystemTime(new Date(2026, 0, 1, 0, 0, 0));
-      const app = buildApp({ limit: 1, windowMs: 1_000, trustProxy: true });
+      const app = buildApp({ limit: 1, windowMs: 1_000, trustedProxyHops: 1 });
 
       const r1 = await app.request("/ping", reqFrom("10.0.0.1"));
       expect(r1.status).toBe(200);
@@ -225,5 +266,62 @@ describe("rateLimit middleware", () => {
       const r3 = await app.request("/ping", reqFrom("10.0.0.1"));
       expect(r3.status).toBe(200);
     });
+  });
+});
+
+describe("validateRateLimitConfig", () => {
+  // validateRateLimitConfig reads process.env at call time, so vi.stubEnv is
+  // enough — no module reset / re-import needed. That keeps the captured
+  // logger instance bound, so the validator's fatal/info lines never leak to
+  // the test runner's stdout.
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+  let restoreLogLevel: () => void;
+  let capture: CaptureStream;
+
+  beforeEach(() => {
+    restoreLogLevel = setLogLevel("trace");
+    capture = new CaptureStream();
+    _setDestinationForTests(capture);
+    exitSpy = vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+      throw new Error(`process.exit(${code})`);
+    }) as never);
+  });
+
+  afterEach(() => {
+    exitSpy.mockRestore();
+    restoreLogLevel();
+    vi.unstubAllEnvs();
+    _setDestinationForTests(undefined);
+  });
+
+  it("does nothing outside production", () => {
+    vi.stubEnv("NODE_ENV", "test");
+    vi.stubEnv("RATE_LIMIT_TRUSTED_PROXY_HOPS", "");
+    expect(() => validateRateLimitConfig()).not.toThrow();
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+
+  it("exits in production when RATE_LIMIT_TRUSTED_PROXY_HOPS is unset", () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("RATE_LIMIT_TRUSTED_PROXY_HOPS", "");
+    expect(() => validateRateLimitConfig()).toThrow(/process\.exit\(1\)/);
+    const fatals = capture.records(LogLevel.FATAL);
+    expect(fatals.length).toBeGreaterThan(0);
+    expect(fatals[0].msg).toMatch(/RATE_LIMIT_TRUSTED_PROXY_HOPS is not set/);
+  });
+
+  it("exits in production when the value is not a non-negative integer", () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("RATE_LIMIT_TRUSTED_PROXY_HOPS", "-1");
+    expect(() => validateRateLimitConfig()).toThrow(/process\.exit\(1\)/);
+    const fatals = capture.records(LogLevel.FATAL);
+    expect(fatals[0].msg).toMatch(/must be a non-negative integer/);
+  });
+
+  it("does not exit in production when a valid value is set", () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("RATE_LIMIT_TRUSTED_PROXY_HOPS", "1");
+    expect(() => validateRateLimitConfig()).not.toThrow();
+    expect(exitSpy).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Closes the first 1.0 blocker (milestone "1.0 blockers"). The per-IP rate limiter had two failure modes that both defeat limiting in a standard "behind a load balancer" deployment.

## Problem
- `trustProxy=true` read the **leftmost** `X-Forwarded-For` entry — client-supplied and spoofable. An attacker rotates it per request and gets a fresh bucket each time.
- `trustProxy=false` (the default) used the socket peer, which behind a proxy is identical for every client → per-IP limiting collapses into a single global bucket one client (or attacker) can exhaust for everyone.

Auth is a single shared `HAOL_API_KEY` (not per-tenant), so IP is the only discriminator available — correct IP resolution is the whole fix.

## Changes
1. **Right-anchored hop resolution.** Replace `trustProxy: boolean` with `trustedProxyHops: number`. The client IP is read from `X-Forwarded-For` counting N entries **from the right** — the entry appended by the proxy nearest this server, which clients can't forge. Entries a client prepends are ignored. A short/missing chain falls back to the socket peer and warns.
2. **Fail-loud config.** `validateRateLimitConfig()` (mirrors `validateApiKeyConfig()`): in production `RATE_LIMIT_TRUSTED_PROXY_HOPS` must be set explicitly (even to `0`) or the server refuses to start. `createApp()` has matching defense-in-depth. This removes the silent-globalization footgun.
3. **Docs.** `.env.example` and README document the env var, hop semantics (`0`/`1`/`2`), the production requirement, and the in-memory/per-process multi-replica caveat (effective limit = `replicas × configured`; use a shared store for coordination).

## Out of scope
Distributed (multi-replica) limiting via a shared store — only relevant if 1.0 ships multi-replica; documented as a constraint for now.

## Testing
- `npm run build` clean.
- Full suite: **529 passed, 6 skipped** (8 new). New/updated tests cover hop semantics, **spoofed-prepend resistance**, `hops=2`, short-chain socket fallback, the `RATE_LIMIT_TRUSTED_PROXY_HOPS` env default, and the startup validator (unset/invalid/valid in production, no-op outside production).