### PR TITLE
Fix #72: stop leaking Zod issue tree to clients

### DIFF
--- a/src/api/middleware/error-handler.ts
+++ b/src/api/middleware/error-handler.ts
@@ -1,4 +1,5 @@
 import type { Context } from "hono";
+import { z } from "zod";
 import { logger } from "../../logging/logger.js";
 
 export class ValidationError extends Error {
@@ -6,6 +7,20 @@ export class ValidationError extends Error {
     super(message);
     this.name = "ValidationError";
   }
+}
+
+/**
+ * Convert a Zod validation failure into a client-safe ValidationError. The
+ * issue tree echoes input fragments back to the caller and exposes internal
+ * schema structure, so we log it server-side only and throw a generic
+ * message. See issue #72 (audit M17).
+ */
+export function rejectInvalidBody(error: z.ZodError): never {
+  logger.warn("request body validation failed", {
+    component: "http",
+    issues: error.issues,
+  });
+  throw new ValidationError("invalid request body");
 }
 
 export class NotFoundError extends Error {
@@ -23,14 +38,19 @@ export class NoAgentAvailableError extends Error {
 }
 
 export function errorHandler(err: Error, c: Context) {
-  if (err instanceof ValidationError || err.name === "ZodError") {
-    return c.json(
-      {
-        error: err.message,
-        details: "details" in err ? (err as Record<string, unknown>).details : undefined,
-      },
-      400,
-    );
+  // A raw ZodError should never reach here — routes are expected to funnel
+  // validation failures through rejectInvalidBody — but if one slips past
+  // (e.g. a .parse() somewhere), fail closed: log the tree, return generic.
+  if (err instanceof z.ZodError) {
+    logger.warn("unhandled zod validation error", {
+      component: "http",
+      issues: err.issues,
+    });
+    return c.json({ error: "invalid request body" }, 400);
+  }
+
+  if (err instanceof ValidationError) {
+    return c.json({ error: err.message }, 400);
   }
 
   if (err instanceof NotFoundError) {

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -8,7 +8,7 @@ import {
   CapabilityValidationError,
 } from "../../services/agent-registry.js";
 import { CreateAgentInput, UpdateAgentInput } from "../../types/agent.js";
-import { NotFoundError, ValidationError } from "../middleware/error-handler.js";
+import { NotFoundError, ValidationError, rejectInvalidBody } from "../middleware/error-handler.js";
 import { parseJsonBody } from "../request-body.js";
 
 const agents = new Hono();
@@ -35,7 +35,7 @@ agents.post("/agents", async (c) => {
   const body = await parseJsonBody(c);
   const parsed = CreateAgentInput.safeParse(body);
   if (!parsed.success) {
-    throw new ValidationError(parsed.error.message);
+    rejectInvalidBody(parsed.error);
   }
 
   const agent = await createAgent(parsed.data).catch(mapCapabilityValidationError);
@@ -47,7 +47,7 @@ agents.put("/agents/:id", async (c) => {
   const body = await parseJsonBody(c);
   const parsed = UpdateAgentInput.safeParse(body);
   if (!parsed.success) {
-    throw new ValidationError(parsed.error.message);
+    rejectInvalidBody(parsed.error);
   }
 
   const existing = await getAgent(agentId);

--- a/src/api/routes/demo.ts
+++ b/src/api/routes/demo.ts
@@ -3,6 +3,7 @@ import { routeTask } from "../../router/router.js";
 import { RouterTaskInput } from "../../types/router.js";
 import { costSavings } from "../../observability/queries.js";
 import { parseJsonBody } from "../request-body.js";
+import { rejectInvalidBody } from "../middleware/error-handler.js";
 
 const demo = new Hono();
 
@@ -18,7 +19,7 @@ demo.post("/demo/api/task", async (c) => {
   const body = await parseJsonBody(c);
   const parsed = RouterTaskInput.safeParse(body);
   if (!parsed.success) {
-    return c.json({ error: parsed.error.message }, 400);
+    rejectInvalidBody(parsed.error);
   }
 
   const input = parsed.data;

--- a/src/api/routes/outcomes.ts
+++ b/src/api/routes/outcomes.ts
@@ -5,6 +5,7 @@ import * as outcomeRepo from "../../repositories/task-outcome.js";
 import * as taskLog from "../../repositories/task-log.js";
 import type { OutcomeSummary } from "../../types/outcome.js";
 import { parseJsonBody } from "../request-body.js";
+import { rejectInvalidBody } from "../middleware/error-handler.js";
 
 const outcomes = new Hono();
 
@@ -15,7 +16,7 @@ outcomes.post("/tasks/:id/outcome", async (c) => {
 
   const result = DownstreamOutcomeInput.safeParse(body);
   if (!result.success) {
-    return c.json({ error: result.error.flatten() }, 400);
+    rejectInvalidBody(result.error);
   }
 
   try {

--- a/src/api/routes/tasks.ts
+++ b/src/api/routes/tasks.ts
@@ -5,7 +5,7 @@ import { findTraceByTaskId } from "../../cascade-router/reference-store.js";
 import { RouterTaskInput } from "../../types/router.js";
 import { uuidv7, sha256 } from "../../types/task.js";
 import * as worker from "../../services/task-worker.js";
-import { NotFoundError, ValidationError } from "../middleware/error-handler.js";
+import { NotFoundError, rejectInvalidBody } from "../middleware/error-handler.js";
 import { parseJsonBody } from "../request-body.js";
 import type { HonoEnv } from "../types.js";
 import { logger } from "../../logging/logger.js";
@@ -23,7 +23,7 @@ tasks.post("/tasks", async (c) => {
   const body = await parseJsonBody(c);
   const parsed = RouterTaskInput.safeParse(body);
   if (!parsed.success) {
-    throw new ValidationError(parsed.error.message);
+    rejectInvalidBody(parsed.error);
   }
 
   // Backpressure: refuse intake before writing a QUEUED row when the

--- a/tests/api/middleware/error-handler.test.ts
+++ b/tests/api/middleware/error-handler.test.ts
@@ -6,6 +6,7 @@ import {
   ValidationError,
   NotFoundError,
   NoAgentAvailableError,
+  rejectInvalidBody,
 } from "../../../src/api/middleware/error-handler.js";
 import { _setDestinationForTests } from "../../../src/logging/logger.js";
 import { CaptureStream, LogLevel, setLogLevel } from "../../helpers/capture-stream.js";
@@ -39,37 +40,51 @@ describe("errorHandler", () => {
     const app = buildAppThatThrows(new ValidationError("bad input shape"));
     const res = await app.request("/boom");
     expect(res.status).toBe(400);
-    expect(await res.json()).toEqual({ error: "bad input shape", details: undefined });
+    expect(await res.json()).toEqual({ error: "bad input shape" });
   });
 
-  it("maps a ZodError (by name) to 400", async () => {
-    // The handler matches by err.name === "ZodError" so it works whether the
-    // app throws a real ZodError or a wrapped one with the same name.
-    const schema = z.object({ count: z.number() });
-    const parsed = schema.safeParse({ count: "nope" });
-    expect(parsed.success).toBe(false);
+  it("fails closed on a raw ZodError: generic message, issue tree logged not returned", async () => {
+    // Routes should funnel validation through rejectInvalidBody, but if a raw
+    // ZodError ever bubbles up we must not echo the issue tree to the client.
+    const schema = z.object({ secretField: z.number() });
+    const parsed = schema.safeParse({ secretField: "nope" });
     const zodError = parsed.success ? null : parsed.error;
-    expect(zodError?.name).toBe("ZodError");
+    expect(zodError).toBeInstanceOf(z.ZodError);
 
     const app = buildAppThatThrows(zodError);
     const res = await app.request("/boom");
     expect(res.status).toBe(400);
-    const body = (await res.json()) as { error: string };
-    expect(typeof body.error).toBe("string");
+    const body = (await res.json()) as { error: string; details?: unknown };
+    expect(body.error).toBe("invalid request body");
+    // The internal schema/field names must not leak in the response.
+    expect(JSON.stringify(body)).not.toMatch(/secretField/);
+    expect(body.details).toBeUndefined();
+    // But the tree is logged server-side for operators.
+    const warns = capture.records(LogLevel.WARN);
+    expect(warns.some((r) => r.msg === "unhandled zod validation error")).toBe(true);
   });
 
-  it("forwards a `details` field on validation errors when present", async () => {
-    class DetailedValidationError extends ValidationError {
-      details: unknown;
-      constructor(message: string, details: unknown) {
-        super(message);
-        this.details = details;
-      }
-    }
-    const app = buildAppThatThrows(new DetailedValidationError("bad", { field: "x" }));
+  it("rejectInvalidBody throws a generic ValidationError and logs the issue tree", async () => {
+    const schema = z.object({ promptField: z.string() });
+    const parsed = schema.safeParse({ promptField: 123 });
+    const zodError = parsed.success ? null : parsed.error;
+
+    const app = new Hono();
+    app.get("/boom", () => {
+      rejectInvalidBody(zodError!);
+    });
+    app.onError(errorHandler);
+
     const res = await app.request("/boom");
     expect(res.status).toBe(400);
-    expect(await res.json()).toEqual({ error: "bad", details: { field: "x" } });
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("invalid request body");
+    expect(JSON.stringify(body)).not.toMatch(/promptField/);
+    // Detailed issues are logged for debugging, not returned.
+    const warns = capture.records(LogLevel.WARN);
+    const rec = warns.find((r) => r.msg === "request body validation failed");
+    expect(rec).toBeDefined();
+    expect(JSON.stringify(rec)).toMatch(/promptField/);
   });
 
   it("maps NotFoundError to 404", async () => {


### PR DESCRIPTION
Closes #72.

## Problem
`errorHandler` echoed `ZodError` messages — the JSON-stringified issue tree — straight back to the caller, exposing input fragments and internal schema structure. Route handlers compounded this by throwing `ValidationError(parsed.error.message)` (and one `result.error.flatten()`), so the tree reached clients even without hitting the handler's `ZodError` branch. The handler also keyed on `err.name === "ZodError"`, which is fragile across library versions and bundling.

## Fix
- Add `rejectInvalidBody(error)`: logs the full issue tree server-side (`warn`) and throws a generic `"invalid request body"` ValidationError. Routed the five validation call sites (`tasks`, `demo`, `agents` ×2, `outcomes`) through it.
- Replace `err.name === "ZodError"` with `instanceof z.ZodError`; a raw ZodError reaching the handler now **fails closed** to the generic message with the tree logged, not returned.
- Drop the unused `details` passthrough that could forward internals.

The malformed-JSON path (`parseJsonBody` → `"Invalid JSON request body"`) is unchanged.

## Tests
- Updated handler tests for the new contract.
- Added leak-prevention coverage: response body must not contain internal field names; issue tree must appear in server logs only.
- Full suite: **365 passed**, 186 skipped (Dolt-dependent); `npm run build` clean.

Audit ref: M17.