### PR TITLE
Fix #80: mark row FAILED when claimQueued errors

### DIFF
--- a/src/services/task-worker.ts
+++ b/src/services/task-worker.ts
@@ -133,7 +133,19 @@ async function runJobInner(job: Job): Promise<void> {
   try {
     claimed = await taskLog.claimQueued(job.taskId);
   } catch (err) {
-    logger.warn("claimQueued failed", { error: (err as Error).message });
+    // A DB outage during the claim leaves the row in QUEUED, where a polling
+    // client sees no progress until the next reaper sweep. Best-effort mark
+    // it FAILED so GET /tasks/:id reaches a terminal state promptly; if this
+    // write also fails (DB still down) the reaper remains the backstop.
+    const message = err instanceof Error ? err.message : String(err);
+    logger.warn("claimQueued failed", { error: message });
+    try {
+      await taskLog.recordWorkerError(job.taskId, `claim_failed: ${message}`);
+    } catch (writeErr) {
+      logger.error("failed to record claim_failed worker_error", {
+        error: (writeErr as Error).message,
+      });
+    }
     return;
   }
   if (!claimed) return;

--- a/tests/services/task-worker.test.ts
+++ b/tests/services/task-worker.test.ts
@@ -181,6 +181,39 @@ describe("task-worker", () => {
     const count = (rows as unknown as Array<{ n: number }>)[0].n;
     expect(Number(count)).toBe(1);
   });
+
+  it("claimQueued DB error → row reaches FAILED with claim_failed worker_error", async ({
+    skip,
+  }) => {
+    if (!doltAvailable) skip();
+    mockProviderSuccess("should-not-run");
+
+    const taskId = uuidv7();
+    const prompt = `${TEST_PROMPT_PREFIX}claim failure`;
+    await taskLog.createQueued(taskId, sha256(prompt), { prompt });
+
+    // Simulate a DB outage during the claim. The row must not be left stuck
+    // in QUEUED — the worker should mark it FAILED so polling clients see a
+    // terminal state without waiting for the reaper.
+    const claimSpy = vi
+      .spyOn(taskLog, "claimQueued")
+      .mockRejectedValueOnce(new Error("connection lost"));
+    try {
+      worker.enqueue(taskId, { prompt });
+      const finished = await pollUntilDone(taskId);
+      expect(finished.status).toBe("FAILED");
+      expect(finished.worker_error).toMatch(/^claim_failed: connection lost/);
+      // routeTask must never have run for this task.
+      const pool = getPool();
+      const [rows] = await pool.query<RowDataPacket[]>(
+        "SELECT COUNT(*) AS n FROM execution_log WHERE task_id = ?",
+        [taskId],
+      );
+      expect(Number(rows[0].n)).toBe(0);
+    } finally {
+      claimSpy.mockRestore();
+    }
+  });
 });
 
 describe("task-reaper", () => {


### PR DESCRIPTION
Closes #80.

## Problem
In `src/services/task-worker.ts`, a DB outage during `claimQueued` logged a warning and returned without surfacing anything. The `task_log` row stayed `QUEUED`, and a polling client saw no progress until the next reaper sweep — the worst failure mode for an async-intake API (task accepted, never runs, never errors).

## Fix
Best-effort mark the row `FAILED` with `worker_error="claim_failed: ..."` so `GET /tasks/:id` reaches a terminal state promptly. If that write also fails (DB still down), the reaper remains the backstop. This mirrors the existing `recordWorkerError` best-effort pattern in the `routeTask` catch directly below it.

The `claimQueued` **returns false** path (a legitimate duplicate / reaper race) is unchanged — only a genuine throw triggers the FAILED write.

## Tests
- Added a worker test that spies `claimQueued` to reject with a DB error and asserts the row reaches `FAILED` with the `claim_failed:` prefix, and that `routeTask` never ran (no `execution_log` row).
- Full suite green against live Dolt: **546 passed**, 6 skipped; `npm run build` clean.

Audit ref: M26.