### PR TITLE
Fix #77: transition tier-2 eval row in place instead of two inserts

### DIFF
--- a/src/repositories/task-outcome.ts
+++ b/src/repositories/task-outcome.ts
@@ -2,6 +2,7 @@ import { getPool } from "../db/connection.js";
 import { query } from "../db/connection.js";
 import type { ResultSetHeader, RowDataPacket } from "mysql2/promise";
 import type { TaskOutcomeRecord } from "../types/outcome.js";
+import { logger } from "../logging/logger.js";
 
 interface TaskOutcomeRow extends RowDataPacket {
   outcome_id: string;
@@ -100,12 +101,22 @@ export async function finalizeEvaluation(
   detail: Record<string, unknown> | null,
 ): Promise<void> {
   const pool = getPool();
-  await pool.query(
+  const [result] = await pool.query<ResultSetHeader>(
     `UPDATE task_outcome
        SET signal_type = ?, signal_value = ?, detail = ?
      WHERE outcome_id = ?`,
     [signalType, signalValue, detail ? JSON.stringify(detail) : null, outcomeId],
   );
+  // A zero-row update means the pending row was already gone (e.g. reaped by
+  // the cleanup sweep, or its insert never landed). Best-effort, but surface
+  // it so a silently discarded evaluation result is observable.
+  if ((result.affectedRows ?? 0) === 0) {
+    logger.warn("finalizeEvaluation matched no row; evaluation result discarded", {
+      component: "task-outcome",
+      outcome_id: outcomeId,
+      signal_type: signalType,
+    });
+  }
 }
 
 export async function findByTaskId(taskId: string): Promise<TaskOutcomeRecord[]> {

--- a/src/repositories/task-outcome.ts
+++ b/src/repositories/task-outcome.ts
@@ -104,12 +104,15 @@ export async function finalizeEvaluation(
   const [result] = await pool.query<ResultSetHeader>(
     `UPDATE task_outcome
        SET signal_type = ?, signal_value = ?, detail = ?
-     WHERE outcome_id = ?`,
+     WHERE outcome_id = ?
+       AND signal_type = 'evaluation_pending'`,
     [signalType, signalValue, detail ? JSON.stringify(detail) : null, outcomeId],
   );
   // A zero-row update means the pending row was already gone (e.g. reaped by
-  // the cleanup sweep, or its insert never landed). Best-effort, but surface
-  // it so a silently discarded evaluation result is observable.
+  // the cleanup sweep, its insert never landed, or finalize was called twice
+  // on the same row). The signal_type guard keeps this a loggable no-op rather
+  // than a silent overwrite. Best-effort, but surface it so a discarded
+  // evaluation result is observable.
   if ((result.affectedRows ?? 0) === 0) {
     logger.warn("finalizeEvaluation matched no row; evaluation result discarded", {
       component: "task-outcome",

--- a/src/repositories/task-outcome.ts
+++ b/src/repositories/task-outcome.ts
@@ -85,6 +85,29 @@ export async function insertBatch(records: TaskOutcomeRecord[]): Promise<void> {
   );
 }
 
+/**
+ * Transition an existing tier-2 evaluation_pending row to its terminal
+ * signal_type (evaluation_complete / evaluation_failed) in place. Updating
+ * the same row — rather than inserting a second record — means a process
+ * death during the LLM call can never leave a pending row paired with a
+ * separate complete row; at worst the single pending row survives for the
+ * cleanup sweep. See issue #77 (audit M22).
+ */
+export async function finalizeEvaluation(
+  outcomeId: string,
+  signalType: "evaluation_complete" | "evaluation_failed",
+  signalValue: 0 | 1 | null,
+  detail: Record<string, unknown> | null,
+): Promise<void> {
+  const pool = getPool();
+  await pool.query(
+    `UPDATE task_outcome
+       SET signal_type = ?, signal_value = ?, detail = ?
+     WHERE outcome_id = ?`,
+    [signalType, signalValue, detail ? JSON.stringify(detail) : null, outcomeId],
+  );
+}
+
 export async function findByTaskId(taskId: string): Promise<TaskOutcomeRecord[]> {
   const rows = await query<TaskOutcomeRow[]>(
     "SELECT * FROM task_outcome WHERE task_id = ? ORDER BY created_at, outcome_id",

--- a/src/services/outcome-collector.ts
+++ b/src/services/outcome-collector.ts
@@ -200,6 +200,11 @@ export async function evaluateRoutingDecision(taskId: string): Promise<void> {
   const task = await taskLog.findById(taskId);
   if (!task) return;
 
+  // Bail before writing the pending row when we can't evaluate at all — an
+  // unconditional insert here would leave a permanent orphan for the cleanup
+  // sweep every time the key is unset.
+  if (!process.env.ANTHROPIC_API_KEY) return;
+
   // Insert a pending record so there's an audit trail that evaluation was attempted
   const pendingRecord: TaskOutcomeRecord = {
     outcome_id: uuidv7(),
@@ -220,10 +225,6 @@ export async function evaluateRoutingDecision(taskId: string): Promise<void> {
 
   // Perform LLM evaluation via Claude Haiku using the provider abstraction
   try {
-    if (!process.env.ANTHROPIC_API_KEY) {
-      return; // Cannot evaluate without API key
-    }
-
     // Gather execution data for this task
     const execRecords = await execRepo.findByTaskId(taskId);
     const successRecord = execRecords.find((r) => r.outcome === "SUCCESS");

--- a/src/services/outcome-collector.ts
+++ b/src/services/outcome-collector.ts
@@ -251,12 +251,17 @@ export async function evaluateRoutingDecision(taskId: string): Promise<void> {
     const signalValue = parseEvaluationResponse(responseText);
 
     // Transition the pending row to complete in place (see finalizeEvaluation).
-    await outcomeRepo.finalizeEvaluation(pendingRecord.outcome_id, "evaluation_complete", signalValue, {
-      complexity_tier: task.complexity_tier,
-      routing_layer: task.routing_layer,
-      selected_agent_id: task.selected_agent_id,
-      llm_reason: extractReason(responseText),
-    });
+    await outcomeRepo.finalizeEvaluation(
+      pendingRecord.outcome_id,
+      "evaluation_complete",
+      signalValue,
+      {
+        complexity_tier: task.complexity_tier,
+        routing_layer: task.routing_layer,
+        selected_agent_id: task.selected_agent_id,
+        llm_reason: extractReason(responseText),
+      },
+    );
   } catch (err) {
     // Transition the same pending row to failed in place so it is never left
     // orphaned. Truly best-effort — if the update also fails (DB down), the

--- a/src/services/outcome-collector.ts
+++ b/src/services/outcome-collector.ts
@@ -250,44 +250,23 @@ export async function evaluateRoutingDecision(taskId: string): Promise<void> {
     const responseText = llmResponse.content;
     const signalValue = parseEvaluationResponse(responseText);
 
-    // Insert the completed evaluation as a separate record
-    const evalRecord: TaskOutcomeRecord = {
-      outcome_id: uuidv7(),
-      task_id: taskId,
-      tier: 2,
-      source: "routing_eval",
-      signal_type: "evaluation_complete",
-      signal_value: signalValue,
-      confidence: task.routing_confidence,
-      detail: {
-        complexity_tier: task.complexity_tier,
-        routing_layer: task.routing_layer,
-        selected_agent_id: task.selected_agent_id,
-        llm_reason: extractReason(responseText),
-      },
-      reported_by: null,
-    };
-
-    await outcomeRepo.insert(evalRecord);
+    // Transition the pending row to complete in place (see finalizeEvaluation).
+    await outcomeRepo.finalizeEvaluation(pendingRecord.outcome_id, "evaluation_complete", signalValue, {
+      complexity_tier: task.complexity_tier,
+      routing_layer: task.routing_layer,
+      selected_agent_id: task.selected_agent_id,
+      llm_reason: extractReason(responseText),
+    });
   } catch (err) {
-    // Record the failure so the pending record doesn't become orphaned
-    const failedRecord: TaskOutcomeRecord = {
-      outcome_id: uuidv7(),
-      task_id: taskId,
-      tier: 2,
-      source: "routing_eval",
-      signal_type: "evaluation_failed",
-      signal_value: null,
-      confidence: task.routing_confidence,
-      detail: {
-        error: err instanceof Error ? err.message : "unknown",
-      },
-      reported_by: null,
-    };
+    // Transition the same pending row to failed in place so it is never left
+    // orphaned. Truly best-effort — if the update also fails (DB down), the
+    // cleanup sweep collects the still-pending row.
     try {
-      await outcomeRepo.insert(failedRecord);
+      await outcomeRepo.finalizeEvaluation(pendingRecord.outcome_id, "evaluation_failed", null, {
+        error: err instanceof Error ? err.message : "unknown",
+      });
     } catch {
-      // truly best-effort — if DB insert also fails, nothing to do
+      // truly best-effort — if the update also fails, nothing to do
     }
   }
 

--- a/tests/services/outcome-collector.test.ts
+++ b/tests/services/outcome-collector.test.ts
@@ -384,7 +384,9 @@ describe("evaluateRoutingDecision — failure handling", () => {
     );
   });
 
-  it("inserts evaluation_failed record when LLM call fails", async ({ skip }) => {
+  it("transitions the pending row to evaluation_failed in place when the LLM call fails", async ({
+    skip,
+  }) => {
     if (!doltAvailable) skip();
     // Set an invalid API key to force the provider to fail
     const originalKey = process.env.ANTHROPIC_API_KEY;
@@ -400,8 +402,11 @@ describe("evaluateRoutingDecision — failure handling", () => {
     }
 
     const signals = await outcomeRepo.findByTaskIdAndTier(testId, 2);
-    const pendingSignal = signals.find((s) => s.signal_type === "evaluation_pending");
-    expect(pendingSignal).toBeDefined();
+    // The pending row is updated in place, not paired with a second record:
+    // exactly one tier-2 row exists and it is the failed terminal state, with
+    // no lingering evaluation_pending row to orphan. See issue #77.
+    expect(signals).toHaveLength(1);
+    expect(signals.find((s) => s.signal_type === "evaluation_pending")).toBeUndefined();
 
     const failedSignal = signals.find((s) => s.signal_type === "evaluation_failed");
     expect(failedSignal).toBeDefined();

--- a/tests/services/outcome-collector.test.ts
+++ b/tests/services/outcome-collector.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
 import { createPool, getPool, query, destroy } from "../../src/db/connection.js";
 import { loadConfig } from "../../src/config.js";
 import { runMigrations } from "../../src/db/migrate.js";
@@ -413,6 +413,66 @@ describe("evaluateRoutingDecision — failure handling", () => {
     expect(failedSignal!.signal_value).toBeNull();
     expect(failedSignal!.detail).toBeDefined();
     expect((failedSignal!.detail as Record<string, unknown>).error).toBeDefined();
+  });
+});
+
+describe("evaluateRoutingDecision — success handling", () => {
+  const testId = `test-oco-evalok-${Date.now()}`;
+  const originalFetch = globalThis.fetch;
+
+  beforeAll(async () => {
+    if (!doltAvailable) return;
+    const pool = getPool();
+    await pool.query(
+      `INSERT INTO task_log (task_id, status, prompt_hash, routing_confidence, complexity_tier, routing_layer)
+       VALUES (?, 'COMPLETED', 'hash-evalok', 0.4, 2, 'semantic')`,
+      [testId],
+    );
+  });
+
+  afterAll(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("transitions the pending row to evaluation_complete in place when the LLM call succeeds", async ({
+    skip,
+  }) => {
+    if (!doltAvailable) skip();
+    // Mock the Anthropic call so the evaluation reaches the success path.
+    globalThis.fetch = vi.fn().mockImplementation(async () => ({
+      ok: true,
+      json: async () => ({
+        content: [{ text: '{"verdict":"YES","reason":"tier matches capabilities"}' }],
+        usage: { input_tokens: 10, output_tokens: 5 },
+        model: "mock",
+        stop_reason: "end_turn",
+      }),
+    })) as unknown as typeof fetch;
+
+    const originalKey = process.env.ANTHROPIC_API_KEY;
+    process.env.ANTHROPIC_API_KEY = "sk-test-key";
+    try {
+      await evaluateRoutingDecision(testId);
+    } finally {
+      if (originalKey) {
+        process.env.ANTHROPIC_API_KEY = originalKey;
+      } else {
+        delete process.env.ANTHROPIC_API_KEY;
+      }
+    }
+
+    const signals = await outcomeRepo.findByTaskIdAndTier(testId, 2);
+    // Symmetric to the failure path: exactly one tier-2 row, terminal complete
+    // state, no lingering pending row. See issue #77.
+    expect(signals).toHaveLength(1);
+    expect(signals.find((s) => s.signal_type === "evaluation_pending")).toBeUndefined();
+
+    const completeSignal = signals.find((s) => s.signal_type === "evaluation_complete");
+    expect(completeSignal).toBeDefined();
+    expect(completeSignal!.signal_value).toBe(1);
+    expect((completeSignal!.detail as Record<string, unknown>).llm_reason).toBe(
+      "tier matches capabilities",
+    );
   });
 });
 


### PR DESCRIPTION
Closes #77.

## Problem
`evaluateRoutingDecision` (`src/services/outcome-collector.ts`) wrote an `evaluation_pending` row, then a *separate* `evaluation_complete` / `evaluation_failed` row. A process death between the two inserts orphaned the pending row until the next cleanup sweep.

## Fix
Update the same row in place rather than inserting a second record:

- Added `task-outcome.finalizeEvaluation(outcomeId, signalType, signalValue, detail)` — a single `UPDATE` that transitions the pending row to its terminal `signal_type`.
- `evaluateRoutingDecision` now finalizes `pendingRecord.outcome_id` in place on both the success and failure paths.

A crash during the LLM call now leaves at most a single `evaluation_pending` row (collected by the existing `cleanupOrphanedPendingRecords` sweep), never an orphaned pending/complete pair. The trailing `doltCommit` still wraps the insert + update into one Dolt commit (also satisfying the issue's second suggested option).

## Tests
- Rewrote the failure-handling test to assert exactly one tier-2 row in the terminal `evaluation_failed` state with no lingering `evaluation_pending` row.
- Full suite green against live Dolt: **546 passed**, 6 skipped; `npm run build` clean.

Audit ref: M22.