### PR TITLE
Fix #75: bound cleanup loop + add (signal_type, task_id) index

### DIFF
--- a/src/db/migrations/023_add_outcome_signal_task_index.sql
+++ b/src/db/migrations/023_add_outcome_signal_task_index.sql
@@ -1,0 +1,21 @@
+-- Index task_outcome (signal_type, task_id) for the orphan-pending cleanup
+-- sweep (cleanupOrphanedPendingRecords / countOrphanedPendingRecords).
+--
+-- Both queries filter task_outcome by signal_type and then probe a second set
+-- of rows keyed on task_id:
+--   - the outer scan finds signal_type = 'evaluation_pending' rows;
+--   - the inner subquery does SELECT DISTINCT task_id WHERE signal_type IN
+--     ('evaluation_complete','evaluation_failed').
+-- With only the existing single-column idx_outcome_signal (signal_type), the
+-- inner DISTINCT had to read task_id from each matching row. The composite
+-- (signal_type, task_id) is covering for that subquery — task_id comes
+-- straight from the index — and the cleanup DELETE batches no longer rescan
+-- the table per batch.
+--
+-- This composite supersedes idx_outcome_signal for these queries (signal_type
+-- is its leftmost column), but that single-column index is left in place;
+-- dropping it is deferred cleanup, not required for the perf fix.
+--
+-- IF NOT EXISTS so a crash between this DDL and the migrations_applied insert
+-- recovers cleanly on re-run (Dolt-supported; see migrations 017/019/021).
+CREATE INDEX IF NOT EXISTS idx_outcome_signal_task ON task_outcome (signal_type, task_id);

--- a/src/repositories/task-outcome.ts
+++ b/src/repositories/task-outcome.ts
@@ -172,19 +172,25 @@ export async function findTasksWithoutTier2Eval(
  * Deletes evaluation_pending records older than maxAgeHours that have
  * no matching evaluation_complete or evaluation_failed record.
  * Deletes in batches of `batchSize` (default 1000) to avoid long-running
- * table-locking transactions. Returns the total number of rows deleted.
+ * table-locking transactions. The loop is bounded at `maxIterations`
+ * (default 1000) so a pathological backlog or a bug that keeps matching the
+ * same rows can never spin forever — at the cap it stops and warns, and the
+ * next scheduled sweep continues. Returns the total number of rows deleted.
  */
 export async function cleanupOrphanedPendingRecords(
   maxAgeHours: number,
   batchSize: number = 1000,
+  maxIterations: number = 1000,
 ): Promise<number> {
   const pool = getPool();
   // The derived table (subquery wrapped in FROM (...) AS t2) is required because
   // MySQL/Dolt forbids a correlated NOT EXISTS that references the same table
   // being deleted from. The count query uses a plain NOT EXISTS since SELECT
-  // doesn't have this restriction.
+  // doesn't have this restriction. idx_outcome_signal_task (signal_type,
+  // task_id) makes the inner DISTINCT scan covering. See migration 023.
   let totalDeleted = 0;
   let batchDeleted: number;
+  let iterations = 0;
   do {
     const [result] = await pool.query<ResultSetHeader>(
       `DELETE FROM task_outcome
@@ -202,7 +208,19 @@ export async function cleanupOrphanedPendingRecords(
     );
     batchDeleted = result.affectedRows ?? 0;
     totalDeleted += batchDeleted;
-  } while (batchDeleted === batchSize);
+    iterations++;
+  } while (batchDeleted === batchSize && iterations < maxIterations);
+
+  // A full final batch means there was more to delete but we stopped on the
+  // cap, not because the backlog drained. Surface it; the next sweep resumes.
+  if (batchDeleted === batchSize && iterations >= maxIterations) {
+    logger.warn("cleanupOrphanedPendingRecords hit iteration cap; backlog remains for next sweep", {
+      component: "task-outcome",
+      deleted: totalDeleted,
+      batch_size: batchSize,
+      max_iterations: maxIterations,
+    });
+  }
   return totalDeleted;
 }
 

--- a/src/repositories/task-outcome.ts
+++ b/src/repositories/task-outcome.ts
@@ -218,6 +218,7 @@ export async function cleanupOrphanedPendingRecords(
       component: "task-outcome",
       deleted: totalDeleted,
       batch_size: batchSize,
+      iterations,
       max_iterations: maxIterations,
     });
   }

--- a/tests/db/migrations.test.ts
+++ b/tests/db/migrations.test.ts
@@ -46,16 +46,16 @@ afterAll(async () => {
 describe("migrations", () => {
   it("applies all migration files without error", async ({ skip }) => {
     if (!doltAvailable) skip();
-    // First call either runs all 22 (fresh DB) or backfills tracking from
+    // First call either runs all 23 (fresh DB) or backfills tracking from
     // an existing populated DB and returns an empty list. Either way the
     // post-condition is "every file recorded in migrations_applied."
     await runMigrations();
     const rows = await query<{ filename: string }>(
       "SELECT filename FROM migrations_applied ORDER BY filename",
     );
-    expect(rows.length).toBe(22);
+    expect(rows.length).toBe(23);
     expect(rows[0].filename).toBe("001_create_agent_registry.sql");
-    expect(rows[21].filename).toBe("022_pii_retention.sql");
+    expect(rows[22].filename).toBe("023_add_outcome_signal_task_index.sql");
   });
 
   it("is idempotent — second run does no work", async ({ skip }) => {

--- a/tests/services/outcome-collector.test.ts
+++ b/tests/services/outcome-collector.test.ts
@@ -531,6 +531,41 @@ describe("cleanupOrphanedPendingRecords", () => {
   });
 });
 
+describe("cleanupOrphanedPendingRecords — iteration cap", () => {
+  const ts = Date.now().toString(36);
+  const taskIds = [0, 1, 2].map((i) => `test-oco-cap${i}-${ts}`);
+
+  beforeAll(async () => {
+    if (!doltAvailable) return;
+    const pool = getPool();
+    // Three distinct old orphaned pending rows so a batchSize=1 sweep needs
+    // more iterations than the cap allows.
+    for (let i = 0; i < taskIds.length; i++) {
+      await pool.query(
+        `INSERT INTO task_log (task_id, status, prompt_hash) VALUES (?, 'COMPLETED', ?)`,
+        [taskIds[i], `hash-cap${i}`],
+      );
+      await pool.query(
+        `INSERT INTO task_outcome (outcome_id, task_id, tier, source, signal_type, signal_value, confidence, detail, reported_by, created_at)
+         VALUES (?, ?, 2, 'routing_eval', 'evaluation_pending', NULL, 0.4, NULL, NULL, DATE_SUB(NOW(), INTERVAL 48 HOUR))`,
+        [`test-oco-capoid${i}-${ts}`, taskIds[i]],
+      );
+    }
+  });
+
+  it("stops at maxIterations and leaves the backlog for the next sweep", async ({ skip }) => {
+    if (!doltAvailable) skip();
+    // batchSize=1, maxIterations=2 → delete exactly 2 even though ≥3 orphans
+    // match, proving the loop is bounded rather than draining everything.
+    const deleted = await outcomeRepo.cleanupOrphanedPendingRecords(24, 1, 2);
+    expect(deleted).toBe(2);
+    // Backlog remains; an unbounded follow-up call drains it.
+    expect(await outcomeRepo.countOrphanedPendingRecords(24)).toBeGreaterThanOrEqual(1);
+    const remaining = await outcomeRepo.cleanupOrphanedPendingRecords(24);
+    expect(remaining).toBeGreaterThanOrEqual(1);
+  });
+});
+
 describe("countOrphanedPendingRecords", () => {
   const ts = Date.now().toString(36);
   const orphanId = `test-oco-cnt-${ts}`;


### PR DESCRIPTION
Closes #75.

## Problem
`cleanupOrphanedPendingRecords` (`src/repositories/task-outcome.ts`) batched its DELETE in an unbounded `do/while`, and the inner `SELECT DISTINCT task_id WHERE signal_type IN (...)` probe rescanned `task_outcome` each batch with only the single-column `idx_outcome_signal (signal_type)` to lean on.

## Fix
- **Migration 023** adds `idx_outcome_signal_task (signal_type, task_id)`. The composite is *covering* for the inner DISTINCT probe (task_id comes straight from the index), so the batched DELETE no longer re-reads the table per batch. `IF NOT EXISTS` for crash-safe re-runs, matching migrations 017/019/021. The existing single-column index is left in place (dropping it is deferred cleanup, noted in the migration).
- **Bounded loop**: added a `maxIterations` cap (default 1000, parameterized so it's testable). At the cap the sweep stops and logs a warning; the next scheduled sweep resumes. A pathological backlog — or a bug that keeps re-matching the same rows — can no longer spin forever.

## Tests
- New iteration-cap test: `batchSize=1, maxIterations=2` deletes exactly 2 even with ≥3 matching orphans, and the backlog remains for an unbounded follow-up call.
- Verified the index is created (`SHOW INDEX`) and migrations re-run cleanly (idempotent).
- Bumped the migration-count assertion to 23.
- Full suite green against live Dolt: **548 passed**, 6 skipped; `npm run build`, prettier, tsc all clean.

Audit ref: M20.