### PR TITLE
Fix #76: enforce one active routing_policy at the schema level

### DIFF
--- a/src/db/migrations/024_routing_policy_one_active.sql
+++ b/src/db/migrations/024_routing_policy_one_active.sql
@@ -1,0 +1,19 @@
+-- Enforce "at most one active routing_policy" at the schema level. Nothing
+-- previously stopped two rows from having active = TRUE, and getActivePolicy
+-- uses LIMIT 1, so a second activation silently produced undefined routing.
+--
+-- The generated marker is 1 when active and NULL otherwise; a UNIQUE key on it
+-- permits unlimited NULLs (inactive rows) but only a single 1. A second INSERT
+-- or an UPDATE that flips another row to active then fails the unique check
+-- (Dolt: "duplicate unique key given: [1]"). Verified against Dolt 2.1.4.
+--
+-- Two statements rather than one combined ALTER so a crash between them
+-- recovers cleanly: re-run hits ER_DUP_FIELDNAME (1060) on the column and
+-- ER_DUP_KEYNAME (1061) on the key, both allow-listed as recoverable in
+-- migrate.ts. If a populated DB already holds two active rows, ADD UNIQUE KEY
+-- fails with a real duplicate — intended: the operator must fix the data first.
+ALTER TABLE routing_policy
+  ADD COLUMN is_active_marker TINYINT GENERATED ALWAYS AS (IF(active, 1, NULL)) STORED;
+
+ALTER TABLE routing_policy
+  ADD UNIQUE KEY uk_one_active (is_active_marker);

--- a/tests/db/migrations.test.ts
+++ b/tests/db/migrations.test.ts
@@ -46,16 +46,16 @@ afterAll(async () => {
 describe("migrations", () => {
   it("applies all migration files without error", async ({ skip }) => {
     if (!doltAvailable) skip();
-    // First call either runs all 23 (fresh DB) or backfills tracking from
+    // First call either runs all 24 (fresh DB) or backfills tracking from
     // an existing populated DB and returns an empty list. Either way the
     // post-condition is "every file recorded in migrations_applied."
     await runMigrations();
     const rows = await query<{ filename: string }>(
       "SELECT filename FROM migrations_applied ORDER BY filename",
     );
-    expect(rows.length).toBe(23);
+    expect(rows.length).toBe(24);
     expect(rows[0].filename).toBe("001_create_agent_registry.sql");
-    expect(rows[22].filename).toBe("023_add_outcome_signal_task_index.sql");
+    expect(rows[23].filename).toBe("024_routing_policy_one_active.sql");
   });
 
   it("is idempotent — second run does no work", async ({ skip }) => {

--- a/tests/db/routing-policy-constraint.test.ts
+++ b/tests/db/routing-policy-constraint.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { createPool, getPool, query, destroy } from "../../src/db/connection.js";
+import { runMigrations } from "../../src/db/migrate.js";
+import { getActivePolicy } from "../../src/repositories/routing-policy.js";
+import { loadConfig } from "../../src/config.js";
+
+let doltAvailable = false;
+
+// Insert a routing_policy row with the given active flag. Columns mirror the
+// seed; is_active_marker is generated and must not be set explicitly.
+async function insertPolicy(policyId: string, active: boolean): Promise<void> {
+  const pool = getPool();
+  await pool.query(
+    `INSERT INTO routing_policy
+       (policy_id, weight_capability, weight_cost, weight_latency, fallback_strategy, max_retries, active)
+     VALUES (?, 0.50, 0.30, 0.20, 'NEXT_BEST', 2, ?)`,
+    [policyId, active],
+  );
+}
+
+describe("routing_policy one-active constraint", () => {
+  beforeAll(async () => {
+    const config = loadConfig();
+    try {
+      getPool();
+    } catch {
+      createPool(config.dolt);
+    }
+    try {
+      await query("SELECT 1");
+      doltAvailable = true;
+      await runMigrations();
+      // Ensure a known active policy exists (seed may not have run).
+      const pool = getPool();
+      await pool.query(
+        `INSERT IGNORE INTO routing_policy
+           (policy_id, weight_capability, weight_cost, weight_latency, fallback_strategy, max_retries, active)
+         VALUES ('default', 0.50, 0.30, 0.20, 'NEXT_BEST', 2, TRUE)`,
+      );
+    } catch {
+      console.warn("Dolt not available — skipping routing_policy constraint tests");
+    }
+  });
+
+  afterAll(async () => {
+    if (doltAvailable) {
+      const pool = getPool();
+      await pool.query("DELETE FROM routing_policy WHERE policy_id LIKE 'test-rp-%'");
+    }
+    await destroy();
+  });
+
+  it("getActivePolicy returns the single active policy", async ({ skip }) => {
+    if (!doltAvailable) skip();
+    const policy = await getActivePolicy();
+    expect(policy).not.toBeNull();
+    expect(policy!.active).toBe(true);
+  });
+
+  it("rejects inserting a second active policy", async ({ skip }) => {
+    if (!doltAvailable) skip();
+    // An inactive row is always allowed (marker is NULL; NULLs may repeat).
+    await insertPolicy("test-rp-inactive", false);
+    // A second active row collides on uk_one_active.
+    await expect(insertPolicy("test-rp-active2", true)).rejects.toThrow();
+  });
+
+  it("rejects activating a second policy via UPDATE", async ({ skip }) => {
+    if (!doltAvailable) skip();
+    await insertPolicy("test-rp-flip", false);
+    const pool = getPool();
+    await expect(
+      pool.query("UPDATE routing_policy SET active = TRUE WHERE policy_id = 'test-rp-flip'"),
+    ).rejects.toThrow();
+  });
+
+  it("allows many inactive policies to coexist", async ({ skip }) => {
+    if (!doltAvailable) skip();
+    await insertPolicy("test-rp-coexist1", false);
+    await insertPolicy("test-rp-coexist2", false);
+    await insertPolicy("test-rp-coexist3", false);
+    const rows = await query<{ n: number }[]>(
+      "SELECT COUNT(*) AS n FROM routing_policy WHERE policy_id LIKE 'test-rp-coexist%' AND active = FALSE",
+    );
+    expect(Number(rows[0].n)).toBe(3);
+  });
+});


### PR DESCRIPTION
Closes #76.

## Problem
Nothing enforced that at most one `routing_policy` row has `active = TRUE`. `getActivePolicy` uses `LIMIT 1`, so two activated policies silently produced undefined routing — whichever row the planner happened to return.

## Fix
**Migration 024** adds a generated marker column with a unique key (the approach suggested in the issue):

```sql
is_active_marker TINYINT GENERATED ALWAYS AS (IF(active, 1, NULL)) STORED
UNIQUE KEY uk_one_active (is_active_marker)
```

NULLs may repeat (any number of inactive rows coexist), but only one row can hold the value `1`. A second active `INSERT`, or an `UPDATE` flipping another row to active, now fails the unique check. Verified against Dolt 2.1.4 — the violation surfaces as `duplicate unique key given: [1]` on both INSERT and UPDATE.

### Notes
- **Two ALTER statements**, not one combined — so a crash between them recovers cleanly via the migrate runner's existing `ER_DUP_FIELDNAME` (1060) / `ER_DUP_KEYNAME` (1061) allowlist (and Dolt's message-collapsed equivalents).
- **Seed unaffected** — it lists explicit columns and never sets the generated marker. Confirmed `npm run seed` still produces exactly one active `default` policy.
- **Existing tests unaffected** — all five that seed a policy use `INSERT IGNORE ... 'default' ... TRUE`, so they converge on a single active row (subsequent inserts are PK no-ops, never a second active row).
- **Purely preventative** — no runtime code currently activates a second policy; this closes the door at the schema level.

## Tests
- New `routing-policy-constraint` suite: `getActivePolicy` returns the single active policy; a second active policy is rejected on both INSERT and UPDATE; many inactive policies coexist.
- Migration-count assertion bumped to 24; verified the migration re-runs idempotently.
- Full suite green against live Dolt: **552 passed**, 6 skipped; `npm run build`, prettier, tsc all clean.

Audit ref: M21.