### PR TITLE
Fix #74: index routing_log near-miss query + tighten window cap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the HAOL (Heterogeneous Agent Orchestration Layer) project are documented in this file.
 
+## [Unreleased]
+
+### Changed
+
+- **Observability time windows are now capped at 90 days** (#74) — All `/v1/observability/*` endpoints that accept a time window (the `hours` query param and the `since` duration string on `/audit/agents`) now clamp to `MAX_WINDOW_HOURS` (2160 hours / 90 days). This bounds the worst-case scan for the `dolt_log` date scans (which cannot be indexed) and the `routing_log` near-miss query. **Behavior change for API consumers:** a request for `hours` greater than 2160 returns data for exactly 2160 hours instead of erroring — the clamping is silent, but the response echoes the effective `window_hours` so callers can detect it.
+
 ## [v0.7.0] — 2026-06-06
 
 A hardening release: audit-driven correctness fixes across the async task pipeline and API validation surface, plus security-driven dependency bumps. No breaking changes.

--- a/src/api/routes/observability.ts
+++ b/src/api/routes/observability.ts
@@ -10,6 +10,7 @@ import {
   outcomeSignalRates,
   routingAccuracyByAgent,
   costSavings,
+  MAX_WINDOW_HOURS,
 } from "../../observability/queries.js";
 import { getDashboard } from "../../observability/dashboard.js";
 import { getCascadeSnapshot, getCascadeTimeseries } from "../../observability/cascade.js";
@@ -23,7 +24,7 @@ import { logger } from "../../logging/logger.js";
 
 const observability = new Hono();
 
-const MAX_HOURS = 8760; // 1 year
+const MAX_HOURS = MAX_WINDOW_HOURS; // 90 days — bounds worst-case scan windows (issue #74)
 
 function parseIntParam(val: string | undefined, def: number, min: number, max: number): number {
   const n = parseInt(val ?? String(def), 10);

--- a/src/api/routes/observability.ts
+++ b/src/api/routes/observability.ts
@@ -24,8 +24,6 @@ import { logger } from "../../logging/logger.js";
 
 const observability = new Hono();
 
-const MAX_HOURS = MAX_WINDOW_HOURS; // 90 days — bounds worst-case scan windows (issue #74)
-
 function parseIntParam(val: string | undefined, def: number, min: number, max: number): number {
   const n = parseInt(val ?? String(def), 10);
   if (isNaN(n)) return def;
@@ -35,31 +33,31 @@ function parseIntParam(val: string | undefined, def: number, min: number, max: n
 // --- Stats routes ---
 
 observability.get("/stats", async (c) => {
-  const hours = parseIntParam(c.req.query("hours"), 24, 1, MAX_HOURS);
+  const hours = parseIntParam(c.req.query("hours"), 24, 1, MAX_WINDOW_HOURS);
   const dashboard = await getDashboard(hours);
   return c.json(dashboard, 200);
 });
 
 observability.get("/stats/cost", async (c) => {
-  const hours = parseIntParam(c.req.query("hours"), 24, 1, MAX_HOURS);
+  const hours = parseIntParam(c.req.query("hours"), 24, 1, MAX_WINDOW_HOURS);
   const data = await costByAgent(hours);
   return c.json(data, 200);
 });
 
 observability.get("/stats/latency", async (c) => {
-  const hours = parseIntParam(c.req.query("hours"), 24, 1, MAX_HOURS);
+  const hours = parseIntParam(c.req.query("hours"), 24, 1, MAX_WINDOW_HOURS);
   const data = await avgLatencyByAgent(hours);
   return c.json(data, 200);
 });
 
 observability.get("/stats/failures", async (c) => {
-  const hours = parseIntParam(c.req.query("hours"), 24, 1, MAX_HOURS);
+  const hours = parseIntParam(c.req.query("hours"), 24, 1, MAX_WINDOW_HOURS);
   const data = await failureRate(hours);
   return c.json(data, 200);
 });
 
 observability.get("/stats/tiers", async (c) => {
-  const hours = parseIntParam(c.req.query("hours"), 24, 1, MAX_HOURS);
+  const hours = parseIntParam(c.req.query("hours"), 24, 1, MAX_WINDOW_HOURS);
   const data = await tasksByTier(hours);
   return c.json(data, 200);
 });
@@ -70,25 +68,25 @@ observability.get("/stats/breaches", async (c) => {
 });
 
 observability.get("/stats/outcomes", async (c) => {
-  const hours = parseIntParam(c.req.query("hours"), 24, 1, MAX_HOURS);
+  const hours = parseIntParam(c.req.query("hours"), 24, 1, MAX_WINDOW_HOURS);
   const data = await outcomeSignalRates(hours);
   return c.json(data, 200);
 });
 
 observability.get("/stats/routing-accuracy", async (c) => {
-  const hours = parseIntParam(c.req.query("hours"), 24, 1, MAX_HOURS);
+  const hours = parseIntParam(c.req.query("hours"), 24, 1, MAX_WINDOW_HOURS);
   const data = await routingAccuracyByAgent(hours);
   return c.json(data, 200);
 });
 
 observability.get("/stats/savings", async (c) => {
-  const hours = parseIntParam(c.req.query("hours"), 24, 1, MAX_HOURS);
+  const hours = parseIntParam(c.req.query("hours"), 24, 1, MAX_WINDOW_HOURS);
   const data = await costSavings(hours);
   return c.json(data, 200);
 });
 
 observability.get("/stats/orphaned-pending", async (c) => {
-  const maxAgeHours = parseIntParam(c.req.query("max_age_hours"), 24, 1, MAX_HOURS);
+  const maxAgeHours = parseIntParam(c.req.query("max_age_hours"), 24, 1, MAX_WINDOW_HOURS);
   const count = await countOrphanedPendingRecords(maxAgeHours);
   return c.json({ orphaned_pending: count, max_age_hours: maxAgeHours }, 200);
 });
@@ -96,7 +94,7 @@ observability.get("/stats/orphaned-pending", async (c) => {
 // --- Cascade router routes ---
 
 observability.get("/cascade", async (c) => {
-  const hours = parseIntParam(c.req.query("hours"), 24, 1, MAX_HOURS);
+  const hours = parseIntParam(c.req.query("hours"), 24, 1, MAX_WINDOW_HOURS);
   // include_text=true opts into raw prompt content in near_misses. Default
   // false so observability access doesn't double as a PII firehose. The
   // server must also be explicitly configured to permit disclosure
@@ -109,7 +107,7 @@ observability.get("/cascade", async (c) => {
 });
 
 observability.get("/cascade/timeseries", async (c) => {
-  const hours = parseIntParam(c.req.query("hours"), 24, 1, MAX_HOURS);
+  const hours = parseIntParam(c.req.query("hours"), 24, 1, MAX_WINDOW_HOURS);
   const bucketRaw = c.req.query("bucket") ?? "hour";
   // Normalize bucket to a number of hours. Reject anything else with 400 so
   // callers can't accidentally request unsupported bucket sizes.
@@ -124,7 +122,7 @@ observability.get("/cascade/timeseries", async (c) => {
 // --- Maintenance routes ---
 
 observability.post("/maintenance/cleanup-pending", async (c) => {
-  const maxAgeHours = parseIntParam(c.req.query("max_age_hours"), 24, 1, MAX_HOURS);
+  const maxAgeHours = parseIntParam(c.req.query("max_age_hours"), 24, 1, MAX_WINDOW_HOURS);
   const deleted = await cleanupOrphanedPendingRecords(maxAgeHours);
   let committed: boolean | null = null;
   if (deleted > 0) {
@@ -148,7 +146,7 @@ observability.post("/maintenance/cleanup-pending", async (c) => {
 // --- Tuning routes ---
 
 observability.post("/tune", async (c) => {
-  const hours = parseIntParam(c.req.query("hours"), 72, 1, MAX_HOURS);
+  const hours = parseIntParam(c.req.query("hours"), 72, 1, MAX_WINDOW_HOURS);
   const dryRun = c.req.query("dry_run") === "true";
   try {
     const result = await tune({ hours, dryRun });

--- a/src/db/migrations/025_add_routing_log_layer_sim_index.sql
+++ b/src/db/migrations/025_add_routing_log_layer_sim_index.sql
@@ -1,0 +1,23 @@
+-- Index routing_log (routing_layer, similarity_score DESC) for the cascade
+-- near-miss query (cascadeNearMisses in cascade-queries.ts):
+--
+--   SELECT ... FROM routing_log
+--   WHERE created_at >= ? AND routing_layer IN ('escalation','fallback')
+--     AND similarity_score IS NOT NULL
+--   ORDER BY similarity_score DESC LIMIT ?
+--
+-- With only idx_log_layer (routing_layer) the planner filtered by layer but
+-- then filesorted the whole time-window slice on similarity_score, spilling to
+-- disk at scale. The composite lets it walk the layer partitions already
+-- ordered by similarity_score, so the ORDER BY ... LIMIT is served from the
+-- index. similarity_score DESC matches the query's sort direction (Dolt 2.1.4
+-- accepts the descending index; an ascending one would also serve it via a
+-- backward scan).
+--
+-- dolt_log date scans (commitHistory / agentRegistryDiff) remain unindexable —
+-- the hours window is now capped server-side and a materialized commit_index
+-- is the deferred long-term fix (see issue #74).
+--
+-- IF NOT EXISTS so a crash between this DDL and the migrations_applied insert
+-- recovers cleanly on re-run (Dolt-supported; see migrations 017/019/021/023).
+CREATE INDEX IF NOT EXISTS idx_log_layer_sim ON routing_log (routing_layer, similarity_score DESC);

--- a/src/observability/queries.ts
+++ b/src/observability/queries.ts
@@ -446,7 +446,7 @@ export function parseDurationToHours(duration: string): number {
     case "h":
       return Math.min(value, MAX_WINDOW_HOURS);
     case "m":
-      return value / 60;
+      return Math.min(value / 60, MAX_WINDOW_HOURS);
     default:
       return 24;
   }

--- a/src/observability/queries.ts
+++ b/src/observability/queries.ts
@@ -431,15 +431,20 @@ export async function costSavings(hours: number): Promise<CostSavingsRow> {
 
 // --- Helpers ---
 
-function parseDurationToHours(duration: string): number {
+// Hard ceiling on any observability time window. Bounds the worst-case scan:
+// routing_log/execution_log slices, and especially the dolt_log date scans
+// (commitHistory / agentRegistryDiff) that cannot be indexed. See issue #74.
+export const MAX_WINDOW_HOURS = 2160; // 90 days
+
+export function parseDurationToHours(duration: string): number {
   const match = duration.match(/^(\d+)([dhm])$/);
   if (!match) return 24; // default to 24 hours
   const value = parseInt(match[1], 10);
   switch (match[2]) {
     case "d":
-      return value * 24;
+      return Math.min(value * 24, MAX_WINDOW_HOURS);
     case "h":
-      return value;
+      return Math.min(value, MAX_WINDOW_HOURS);
     case "m":
       return value / 60;
     default:

--- a/tests/api/observability-cascade.test.ts
+++ b/tests/api/observability-cascade.test.ts
@@ -205,7 +205,7 @@ describe("GET /observability/cascade", () => {
     const res = await app.request("/v1/observability/cascade?hours=999999999");
     expect(res.status).toBe(200);
     const body = (await res.json()) as { window_hours: number };
-    expect(body.window_hours).toBe(2160); // MAX_HOURS — 90 days
+    expect(body.window_hours).toBe(2160); // MAX_WINDOW_HOURS — 90 days
   });
 });
 

--- a/tests/api/observability-cascade.test.ts
+++ b/tests/api/observability-cascade.test.ts
@@ -205,7 +205,7 @@ describe("GET /observability/cascade", () => {
     const res = await app.request("/v1/observability/cascade?hours=999999999");
     expect(res.status).toBe(200);
     const body = (await res.json()) as { window_hours: number };
-    expect(body.window_hours).toBe(8760); // MAX_HOURS
+    expect(body.window_hours).toBe(2160); // MAX_HOURS — 90 days
   });
 });
 

--- a/tests/db/migrations.test.ts
+++ b/tests/db/migrations.test.ts
@@ -46,16 +46,16 @@ afterAll(async () => {
 describe("migrations", () => {
   it("applies all migration files without error", async ({ skip }) => {
     if (!doltAvailable) skip();
-    // First call either runs all 24 (fresh DB) or backfills tracking from
+    // First call either runs all 25 (fresh DB) or backfills tracking from
     // an existing populated DB and returns an empty list. Either way the
     // post-condition is "every file recorded in migrations_applied."
     await runMigrations();
     const rows = await query<{ filename: string }>(
       "SELECT filename FROM migrations_applied ORDER BY filename",
     );
-    expect(rows.length).toBe(24);
+    expect(rows.length).toBe(25);
     expect(rows[0].filename).toBe("001_create_agent_registry.sql");
-    expect(rows[23].filename).toBe("024_routing_policy_one_active.sql");
+    expect(rows[24].filename).toBe("025_add_routing_log_layer_sim_index.sql");
   });
 
   it("is idempotent — second run does no work", async ({ skip }) => {

--- a/tests/observability/queries.test.ts
+++ b/tests/observability/queries.test.ts
@@ -97,6 +97,7 @@ describe("parseDurationToHours", () => {
     // open an arbitrarily wide window. See issue #74.
     expect(parseDurationToHours("9999d")).toBe(MAX_WINDOW_HOURS);
     expect(parseDurationToHours("100000h")).toBe(MAX_WINDOW_HOURS);
+    expect(parseDurationToHours("9999999m")).toBe(MAX_WINDOW_HOURS);
     expect(MAX_WINDOW_HOURS).toBe(2160);
   });
 });

--- a/tests/observability/queries.test.ts
+++ b/tests/observability/queries.test.ts
@@ -12,6 +12,8 @@ import {
   agentRegistryDiff,
   outcomeSignalRates,
   costSavings,
+  parseDurationToHours,
+  MAX_WINDOW_HOURS,
 } from "../../src/observability/queries.js";
 
 let doltAvailable = false;
@@ -76,6 +78,27 @@ afterAll(async () => {
     await pool.query(`DELETE FROM task_log WHERE task_id LIKE '${prefix}-%'`);
   }
   await destroy();
+});
+
+describe("parseDurationToHours", () => {
+  it("parses day/hour/minute suffixes", () => {
+    expect(parseDurationToHours("3d")).toBe(72);
+    expect(parseDurationToHours("12h")).toBe(12);
+    expect(parseDurationToHours("30m")).toBe(0.5);
+  });
+
+  it("defaults to 24h on malformed input", () => {
+    expect(parseDurationToHours("garbage")).toBe(24);
+    expect(parseDurationToHours("")).toBe(24);
+  });
+
+  it("caps the window at MAX_WINDOW_HOURS (90 days)", () => {
+    // dolt_log date scans can't be indexed, so an unbounded `since` must not
+    // open an arbitrarily wide window. See issue #74.
+    expect(parseDurationToHours("9999d")).toBe(MAX_WINDOW_HOURS);
+    expect(parseDurationToHours("100000h")).toBe(MAX_WINDOW_HOURS);
+    expect(MAX_WINDOW_HOURS).toBe(2160);
+  });
 });
 
 describe("costByAgent", () => {


### PR DESCRIPTION
Closes #74.

## Problem
`cascadeNearMisses` (`src/observability/cascade-queries.ts`) filters `routing_log` by `routing_layer IN ('escalation','fallback')` and then `ORDER BY similarity_score DESC LIMIT N`. With only `idx_log_layer (routing_layer)` the planner filtered by layer but filesorted the whole time-window slice on `similarity_score`, spilling to disk at scale. Separately, the `hours` window was capped only at 1 year, and the `since`-based `dolt_log` scans (`commitHistory` / `agentRegistryDiff`) were uncapped entirely — and `dolt_log` can't be indexed on date.

## Fix
- **Migration 025** adds `idx_log_layer_sim (routing_layer, similarity_score DESC)` — the exact composite the issue recommends. It serves the `IN`-filter + `ORDER BY ... LIMIT` from the index instead of a filesort. Verified Dolt 2.1.4 accepts the descending index (an ascending one would also serve it via a backward scan). `IF NOT EXISTS` for crash-safe re-runs.
- **90-day window cap** via a shared `MAX_WINDOW_HOURS = 2160`:
  - `MAX_HOURS` (the `parseIntParam` route clamp) now references it — tightened from 1 year to 90 days.
  - `parseDurationToHours` clamps the `since` duration to it, bounding the unindexable `dolt_log` date scans.

The materialized `commit_index` table remains the deferred long-term fix noted in the issue.

## Tests
- New `parseDurationToHours` unit tests (suffix parsing, malformed-input default, 90-day cap) — pure, no DB.
- Updated the cascade clamp assertion (`hours=999999999` → `2160`).
- Verified the index is created (`SHOW INDEX`) and migrations re-run idempotently; migration count bumped to 25.
- Full suite green against live Dolt: **555 passed**, 6 skipped; `npm run build`, prettier, tsc all clean.

Audit ref: M19.