### PR TITLE
Fix #105: bind tuner advisory lock to a dedicated connection

### DIFF
--- a/src/services/routing-tuner/lock.ts
+++ b/src/services/routing-tuner/lock.ts
@@ -1,6 +1,6 @@
 import { execute, getPool } from "../../db/connection.js";
 import { logger } from "../../logging/logger.js";
-import type { RowDataPacket } from "mysql2/promise";
+import type { PoolConnection, RowDataPacket } from "mysql2/promise";
 import type { TuneResult } from "./types.js";
 
 // ---------------------------------------------------------------------------
@@ -14,34 +14,51 @@ const LOCK_NAME = "haol_tuner";
  * 'running' records left by crashed processes, and inserts a fresh
  * 'running' tuning_run row.
  *
- * GET_LOCK is truly atomic — the DB serializes callers. Throws if another
- * run currently holds the lock.
+ * MySQL's GET_LOCK is **session-scoped**: the lock is owned by the single
+ * connection that acquired it, only that connection can release it, and it
+ * stays held only while that connection is alive. Issuing RELEASE_LOCK on a
+ * different pooled connection is a silent no-op that orphans the lock (#105).
+ *
+ * So the lock is bound to one dedicated connection, checked out from the pool
+ * for the whole run. This function returns that held connection; the caller
+ * MUST pass it to releaseTunerLock, which runs RELEASE_LOCK on it and returns
+ * it to the pool. Throws (after releasing the connection) if another run holds
+ * the lock.
  */
-export async function acquireTunerLock(runId: string, hours: number): Promise<void> {
-  const pool = getPool();
+export async function acquireTunerLock(runId: string, hours: number): Promise<PoolConnection> {
+  const conn = await getPool().getConnection();
 
-  // GET_LOCK returns 1 if acquired, 0 if timed out. Timeout of 0
-  // means fail immediately if another session holds the lock.
-  const [lockRows] = await pool.query<RowDataPacket[]>(`SELECT GET_LOCK(?, 0) AS acquired`, [
-    LOCK_NAME,
-  ]);
-  const acquired = (lockRows as Record<string, unknown>[])[0]?.acquired;
-  if (acquired !== 1) {
-    throw new Error("Another tuning run is already in progress");
+  try {
+    // GET_LOCK returns 1 if acquired, 0 if timed out. Timeout of 0
+    // means fail immediately if another session holds the lock.
+    const [lockRows] = await conn.query<RowDataPacket[]>(`SELECT GET_LOCK(?, 0) AS acquired`, [
+      LOCK_NAME,
+    ]);
+    const acquired = (lockRows as Record<string, unknown>[])[0]?.acquired;
+    if (acquired !== 1) {
+      throw new Error("Another tuning run is already in progress");
+    }
+  } catch (err) {
+    // GET_LOCK failed or the lock was unavailable — nothing is held, so just
+    // hand the connection back to the pool.
+    conn.release();
+    throw err;
   }
 
-  // The lock is held now. If any setup below throws, release it before
-  // propagating — otherwise the advisory lock is orphaned on the pooled
-  // connection and every subsequent run bails with "already in progress".
+  // The lock is held on `conn` now. All setup below runs on the same
+  // connection so it stays alive (and thus the lock stays held). If anything
+  // throws, release the lock on this connection before propagating —
+  // otherwise the lock is orphaned and every subsequent run bails with
+  // "already in progress".
   try {
     // Also check for stale 'running' records from crashed processes
-    const [staleRows] = await pool.query<RowDataPacket[]>(
+    const [staleRows] = await conn.query<RowDataPacket[]>(
       `SELECT run_id FROM tuning_run
        WHERE status = 'running'
          AND started_at < DATE_SUB(NOW(), INTERVAL 1 HOUR)`,
     );
     for (const row of staleRows as Record<string, unknown>[]) {
-      await pool.query(
+      await conn.query(
         `UPDATE tuning_run SET status = 'failed', completed_at = NOW(),
                 error_message = 'Marked stale by subsequent run'
          WHERE run_id = ?`,
@@ -49,22 +66,31 @@ export async function acquireTunerLock(runId: string, hours: number): Promise<vo
       );
     }
 
-    await execute(
+    await conn.query(
       `INSERT INTO tuning_run (run_id, status, hours_window) VALUES (?, 'running', ?)`,
       [runId, hours],
     );
   } catch (err) {
-    await releaseTunerLock();
+    await releaseTunerLock(conn);
     throw err;
   }
+
+  return conn;
 }
 
-/** Releases the advisory lock. Best-effort — it auto-releases on disconnect. */
-export async function releaseTunerLock(): Promise<void> {
+/**
+ * Releases the advisory lock on the connection that acquired it and returns
+ * that connection to the pool. Best-effort on the RELEASE_LOCK itself (the
+ * lock also auto-releases when the connection closes), but the connection is
+ * always released back to the pool.
+ */
+export async function releaseTunerLock(conn: PoolConnection): Promise<void> {
   try {
-    await execute(`SELECT RELEASE_LOCK(?)`, [LOCK_NAME]);
+    await conn.query(`SELECT RELEASE_LOCK(?)`, [LOCK_NAME]);
   } catch {
     // Lock release is best-effort — it auto-releases on disconnect
+  } finally {
+    conn.release();
   }
 }
 

--- a/src/services/routing-tuner/orchestrator.ts
+++ b/src/services/routing-tuner/orchestrator.ts
@@ -1,7 +1,7 @@
 import { execute, getPool } from "../../db/connection.js";
 import { doltCommit } from "../../db/dolt.js";
 import { uuidv7 } from "../../types/task.js";
-import type { ResultSetHeader } from "mysql2/promise";
+import type { PoolConnection, ResultSetHeader } from "mysql2/promise";
 import type { TierId } from "../../cascade-router/types.js";
 import { logger } from "../../logging/logger.js";
 import {
@@ -169,9 +169,12 @@ export async function tune(opts: Partial<TuneOptions> = {}): Promise<TuneResult>
   const runId = uuidv7();
 
   // Acquire an advisory lock to prevent concurrent tuning runs. Runs older
-  // than 1 hour with status='running' are treated as stale (crashed).
+  // than 1 hour with status='running' are treated as stale (crashed). The
+  // lock is bound to a dedicated connection held for the whole run (#105);
+  // releaseTunerLock returns it to the pool in the finally below.
+  let lockConn: PoolConnection | null = null;
   if (!options.dryRun) {
-    await acquireTunerLock(runId, options.hours);
+    lockConn = await acquireTunerLock(runId, options.hours);
   }
 
   try {
@@ -246,8 +249,8 @@ export async function tune(opts: Partial<TuneOptions> = {}): Promise<TuneResult>
     }
     throw err;
   } finally {
-    if (!options.dryRun) {
-      await releaseTunerLock();
+    if (lockConn) {
+      await releaseTunerLock(lockConn);
     }
   }
 }

--- a/tests/services/routing-tuner.test.ts
+++ b/tests/services/routing-tuner.test.ts
@@ -10,6 +10,7 @@ import {
   recentTuningRuns,
   DEFAULT_TUNE_OPTIONS,
 } from "../../src/services/routing-tuner.js";
+import { acquireTunerLock, releaseTunerLock } from "../../src/services/routing-tuner/lock.js";
 
 let doltAvailable = false;
 
@@ -218,6 +219,49 @@ describe("tune (live run)", () => {
 
     // Cleanup
     await getPool().query("DELETE FROM tuning_run WHERE run_id = ?", [result.run_id]);
+  });
+});
+
+describe("tuner advisory lock (connection affinity, #105)", () => {
+  it("holds the lock on its own connection and frees it on release", async ({ skip }) => {
+    if (!doltAvailable) skip();
+
+    // Hold the lock on its dedicated connection. Because that connection is
+    // checked out from the pool, every assertion below runs on a DIFFERENT
+    // pooled connection — so IS_FREE_LOCK (which is session-independent)
+    // genuinely reflects cross-connection state, not the holder's own.
+    const conn = await acquireTunerLock("test-tune-lock-affinity", 1);
+    try {
+      const held = await query<any[]>(`SELECT IS_FREE_LOCK('haol_tuner') AS free`);
+      expect(Number(held[0].free)).toBe(0); // lock is held by `conn`
+    } finally {
+      await releaseTunerLock(conn);
+    }
+
+    // After release the lock must be free. Before the #105 fix, RELEASE_LOCK
+    // ran on a pooled connection that often differed from the acquiring one,
+    // making it a silent no-op — this would still report 0 (held/orphaned).
+    const freed = await query<any[]>(`SELECT IS_FREE_LOCK('haol_tuner') AS free`);
+    expect(Number(freed[0].free)).toBe(1);
+
+    await getPool().query("DELETE FROM tuning_run WHERE run_id = ?", ["test-tune-lock-affinity"]);
+  });
+
+  it("frees the lock after a run so a subsequent run can acquire it", async ({ skip }) => {
+    if (!doltAvailable) skip();
+
+    const first = await tune({ dryRun: false, hours: 1 });
+    // If the first run leaked its lock, this second run would throw
+    // "Another tuning run is already in progress".
+    const second = await tune({ dryRun: false, hours: 1 });
+
+    expect(first.status).toBe("completed");
+    expect(second.status).toBe("completed");
+
+    await getPool().query("DELETE FROM tuning_run WHERE run_id IN (?, ?)", [
+      first.run_id,
+      second.run_id,
+    ]);
   });
 });
 


### PR DESCRIPTION
Closes #105.

## Problem

MySQL's `GET_LOCK()` / `RELEASE_LOCK()` advisory locks are **session-scoped** — the lock is owned by the connection that acquired it, only that connection can release it, and it stays held only while that connection is alive.

In `routing-tuner/lock.ts` the tuner acquired the lock via `pool.query` and released it via a separate `execute()` call. Each goes through the pool and can land on a **different** physical connection, so `RELEASE_LOCK` was often a silent no-op. The orphaned lock then makes every subsequent `tune()` bail with `"Another tuning run is already in progress"` until the holding connection is recycled.

This was the deeper issue flagged while reviewing #104 (PR #104 fixed a separate orphan path but not connection affinity).

### Why it was latent
Under sequential load the pool tends to hand back the *same* physical connection, so acquire and release coincidentally share one and the lock releases fine. The bug only bites under connection divergence — which is exactly why it surfaced as a reasoning finding rather than a failing test.

## Fix

- `acquireTunerLock` now checks out a **dedicated** connection, runs `GET_LOCK` + stale-row cleanup + the `tuning_run` INSERT on it, and returns it **held**.
- `tune()` holds that connection for the run's duration and passes it to `releaseTunerLock`, which runs `RELEASE_LOCK` on the **same** connection and returns it to the pool.
- All-or-nothing acquisition is preserved: any failure after `GET_LOCK` releases the lock (and the connection) before propagating.

Pool size defaults to 5 and the tuner pipeline runs queries sequentially (needs 1 connection at a time), so holding one connection for the run is safe.

## Test

Added a focused integration test (`tuner advisory lock (connection affinity, #105)`) that holds the lock on its dedicated connection and asserts `IS_FREE_LOCK` — which is **session-independent**, unlike `GET_LOCK`, so it can't be fooled by the holder re-acquiring its own lock:
- `held = 0` while the connection holds the lock (verified from a *different* pooled connection),
- `free = 1` after `releaseTunerLock`.

**Verified discriminating:** a mutant that releases on a pooled connection (the #105 bug) fails the test with `free = 0`. A plain sequential end-to-end test does *not* catch it, for the latency reason above — so the test deliberately holds the connection to force divergence.

## Verification
- `npm run build` — clean
- `npm run format:check` — clean
- Full suite against local Dolt: **565 passed, 6 skipped** (tuner file: 20/20, previously 11 passed + 7 skipped without Dolt)